### PR TITLE
Removed bower version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
 	"name": "nette-forms",
 	"description": "Client side script for Nette Forms Component",
-	"version": "2.1.0",
 	"homepage": "http://nette.org",
 	"keywords": [
 		"nette",


### PR DESCRIPTION
I think it better be removed, keeping custom version for bower would be just more overhead without effect.
`bower nette-forms#~2.2        mismatch Version declared in the json (2.1.0) is different than the resolved one (2.2.0)`
