### PR TITLE
Bumped bower version to 2.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
 	"name": "nette-forms",
 	"description": "Client side script for Nette Forms Component",
-	"version": "2.1.0",
+	"version": "2.3.0",
 	"homepage": "http://nette.org",
 	"keywords": [
 		"nette",


### PR DESCRIPTION
I don't think it is necessary, just removal of version in #13 should be enough.
Specific packages can be installed via requiring explicit version `bower install <name>#<tag or branch>`.
