### PR TITLE
ChoiceControl: added option to ignore values out of range

### DIFF
--- a/src/Forms/Controls/ChoiceControl.php
+++ b/src/Forms/Controls/ChoiceControl.php
@@ -18,11 +18,15 @@ use Nette;
  * @property   array $items
  * @property-read mixed $selectedItem
  * @property-read mixed $rawValue
+ * @method setValidateRange(bool $validateRange)
  */
 abstract class ChoiceControl extends BaseControl
 {
 	/** @var array */
 	private $items = array();
+
+	/** @var bool */
+	public $validateRange = TRUE;
 
 
 	public function __construct($label = NULL, array $items = NULL)
@@ -58,7 +62,7 @@ abstract class ChoiceControl extends BaseControl
 	 */
 	public function setValue($value)
 	{
-		if ($value !== NULL && !array_key_exists((string) $value, $this->items)) {
+		if ($this->validateRange && $value !== NULL && !array_key_exists((string) $value, $this->items)) {
 			$range = Nette\Utils\Strings::truncate(implode(', ', array_map(function($s) { return var_export($s, TRUE); }, array_keys($this->items))), 70, '...');
 			throw new Nette\InvalidArgumentException("Value '$value' is out of allowed range [$range] in field '{$this->name}'.");
 		}

--- a/tests/Forms/Controls.ChoiceControl.loadData.phpt
+++ b/tests/Forms/Controls.ChoiceControl.loadData.phpt
@@ -151,6 +151,16 @@ test(function() use ($series) { // setValue() and invalid argument
 });
 
 
+test(function() use ($series) { // setValue() ignore values out of range
+	$form = new Form;
+	$input = $form['select'] = new ChoiceControl(NULL, $series);
+	$input->setValidateRange(FALSE);
+	$input->setValue('unknown');
+	
+	Assert::null( $input->getValue() );
+});
+
+
 test(function() { // object as value
 	$form = new Form;
 	$input = $form['select'] = new ChoiceControl(NULL, array('2013-07-05 00:00:00' => 1));


### PR DESCRIPTION
Added option for ignoring values out of range items. 
There is not easy to catch InvalidArgumentException throwed by ChoiceControl::setValue() when control is filled by Form::setValues(). You must handle it by yourself breake DRY.