### PR TITLE
problem with setEmptyValue() and space at the end of the string

### DIFF
--- a/tests/Forms/Controls.TextBase.loadData.phpt
+++ b/tests/Forms/Controls.TextBase.loadData.phpt
@@ -49,6 +49,17 @@ test(function() { // empty value
 });
 
 
+test(function() { // empty value
+	$_POST = array('phone' => '+420 ');
+
+	$form = new Form;
+	$input = $form->addText('phone')
+		->setEmptyValue('+420 ');
+
+	Assert::same( '', $input->getValue() );
+});
+
+
 test(function() { // invalid UTF
 	$_POST = array('invalidutf' => "invalid\xAA\xAA\xAAutf");
 


### PR DESCRIPTION
Because default behaviour is trim all text inputs, this test fail. Is it possible, to do this works? or is it impossible ? 
