### PR TITLE
Change order of showing error message and focusing element

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -195,11 +195,11 @@ Nette.isDisabled = function(elem) {
  * Display error message.
  */
 Nette.addError = function(elem, message) {
-	if (elem.focus) {
-		elem.focus();
-	}
 	if (message) {
 		alert(message);
+	}
+	if (elem.focus) {
+		elem.focus();
 	}
 };
 


### PR DESCRIPTION
Show alert with error message sooner than setting focus on element. In firefox element lost focus when alert is invoked.
