### PR TITLE
Erasing CsrfProtection control value is ignored [Closes #39]

### DIFF
--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -69,7 +69,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 		}
 
 		foreach ($this->getComponents() as $name => $control) {
-			if ($control instanceof IControl) {
+			if ($control instanceof Nette\Forms\Controls\CsrfProtection) {
+			} elseif ($control instanceof IControl) {
 				if (array_key_exists($name, $values)) {
 					$control->setValue($values[$name]);
 


### PR DESCRIPTION
This pull request solves the problem, but there is better way, I think.

For example, when you use some filter form with two buttons (filter and reset).  Reset button submit invokes setting default values -> erasing all values including CsrfProtection -> CsrfProtection fail.
