### PR TITLE
netteForms: Nette.getValue returns boolean instead of value of radio/checkbox.

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -62,7 +62,7 @@ Nette.getValue = function(elem) {
 		return values;
 
 	} else if (elem.type in {checkbox: 1, radio: 1}) {
-		return elem.checked;
+		return elem.checked === false ? false : elem.value;
 
 	} else if (elem.type === 'file') {
 		return elem.files || elem.value;


### PR DESCRIPTION
If I have only one radio in radioList (1 => 'option one') it works. But If I have radio with 3=>'option three' it doesn't work because Nette.getValue returns true instead of elem.value.
