### PR TITLE
@return $this for better IDE hinting

### DIFF
--- a/src/Forms/Controls/BaseControl.php
+++ b/src/Forms/Controls/BaseControl.php
@@ -146,7 +146,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Sets control's value.
-	 * @return self
+	 * @return $this
 	 */
 	public function setValue($value)
 	{
@@ -178,7 +178,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Sets control's default value.
-	 * @return self
+	 * @return $this
 	 */
 	public function setDefaultValue($value)
 	{
@@ -193,7 +193,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	/**
 	 * Disables or enables control.
 	 * @param  bool
-	 * @return self
+	 * @return $this
 	 */
 	public function setDisabled($value = TRUE)
 	{
@@ -218,7 +218,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	/**
 	 * Sets whether control value is excluded from $form->getValues() result.
 	 * @param  bool
-	 * @return self
+	 * @return $this
 	 */
 	public function setOmitted($value = TRUE)
 	{
@@ -295,7 +295,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	/**
 	 * Changes control's HTML id.
 	 * @param  string new ID, or FALSE or NULL
-	 * @return self
+	 * @return $this
 	 */
 	public function setHtmlId($id)
 	{
@@ -321,7 +321,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	 * Changes control's HTML attribute.
 	 * @param  string name
 	 * @param  mixed  value
-	 * @return self
+	 * @return $this
 	 */
 	public function setAttribute($name, $value = TRUE)
 	{
@@ -335,7 +335,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Sets translate adapter.
-	 * @return self
+	 * @return $this
 	 */
 	public function setTranslator(Nette\Localization\ITranslator $translator = NULL)
 	{
@@ -385,7 +385,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	 * @param  mixed      rule type
 	 * @param  string     message to display for invalid data
 	 * @param  mixed      optional rule arguments
-	 * @return self
+	 * @return $this
 	 */
 	public function addRule($validator, $message = NULL, $arg = NULL)
 	{
@@ -431,7 +431,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	/**
 	 * Makes control mandatory.
 	 * @param  mixed  state or error message
-	 * @return self
+	 * @return $this
 	 */
 	public function setRequired($value = TRUE)
 	{
@@ -518,7 +518,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Sets user-specific option.
-	 * @return self
+	 * @return $this
 	 */
 	public function setOption($key, $value)
 	{


### PR DESCRIPTION
`@return self` confuses IDE to think that returned value is a BaseControl object. `@return $this` preserves the class and doesn't mark subsequent calls to getSeparatorControl() (and others) as invalid.

![After change](https://cloud.githubusercontent.com/assets/853656/5214559/4295e734-761e-11e4-8719-ba9402553eb2.png)
![Before change](https://cloud.githubusercontent.com/assets/853656/5214560/429864fa-761e-11e4-9e18-4e7c59290e3f.PNG)
