### PR TITLE
Exclude examples folder for Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
 		"src/Bridges",
 		"src/Forms",
 		"tests",
+		"examples",
 		"**/.*",
 		"*.json"
 	]


### PR DESCRIPTION
I think that examples should be excluded when installing through Bower, because the primary reason is to obtain netteForms.js. @vojtech-dobes's nette.ajax.js is dependant on this repository and including PHP code is, in my opinion, not only unneeded as it bloats the project, but also bad practise – Bower should be used for web component distribution, so shouldn't include PHP scripts if they're not directly related. For everything other we have Composer.

What are your thoughts?
