### PR TITLE
BaseControl, SelectBox: labels and prompt are translated by global translator

### DIFF
--- a/src/Forms/Controls/BaseControl.php
+++ b/src/Forms/Controls/BaseControl.php
@@ -266,7 +266,9 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	{
 		$label = clone $this->label;
 		$label->for = $this->getHtmlId();
-		$label->setText($this->translate($caption === NULL ? $this->caption : $caption));
+		$caption = $caption === NULL ? $this->caption : $caption;
+		$translator = $this->getForm()->getTranslator();
+		$label->setText($translator ? $translator->translate($caption) : $caption);
 		return $label;
 	}
 

--- a/tests/Forms/Controls.Checkbox.render.phpt
+++ b/tests/Forms/Controls.Checkbox.render.phpt
@@ -49,7 +49,7 @@ test(function () { // Html with translator
 	$input = $form->addCheckbox('on', 'Label');
 	$input->setTranslator(new Translator);
 
-	Assert::same('<label for="frm-on"><input type="checkbox" name="on" id="frm-on">LABEL</label>', (string) $input->getControl());
+	Assert::same('<label for="frm-on"><input type="checkbox" name="on" id="frm-on">Label</label>', (string) $input->getControl());
 });
 
 

--- a/tests/Forms/Controls.CheckboxList.render.phpt
+++ b/tests/Forms/Controls.CheckboxList.render.phpt
@@ -64,8 +64,8 @@ test(function () { // translator
 	]);
 	$input->setTranslator(new Translator);
 
-	Assert::same('<label>LABEL</label>', (string) $input->getLabel());
-	Assert::same('<label>ANOTHER LABEL</label>', (string) $input->getLabel('Another label'));
+	Assert::same('<label>Label</label>', (string) $input->getLabel());
+	Assert::same('<label>Another label</label>', (string) $input->getLabel('Another label'));
 	Assert::same('<label for="frm-list-0">SECOND</label>', (string) $input->getLabelPart(0));
 
 	Assert::same('<label><input type="checkbox" name="list[]" value="a">FIRST</label><br><label><input type="checkbox" name="list[]" value="0">SECOND</label>', (string) $input->getControl());

--- a/tests/Forms/Controls.MultiSelectBox.render.phpt
+++ b/tests/Forms/Controls.MultiSelectBox.render.phpt
@@ -69,8 +69,8 @@ test(function () { // translator & groups
 	]);
 	$input->setTranslator(new Translator);
 
-	Assert::same('<label for="frm-list">LABEL</label>', (string) $input->getLabel());
-	Assert::same('<label for="frm-list">ANOTHER LABEL</label>', (string) $input->getLabel('Another label'));
+	Assert::same('<label for="frm-list">Label</label>', (string) $input->getLabel());
+	Assert::same('<label for="frm-list">Another label</label>', (string) $input->getLabel('Another label'));
 	Assert::same('<select name="list[]" id="frm-list" multiple><option value="a">FIRST</option><optgroup label="GROUP"><option value="0">SECOND</option><option value="1">THIRD</option></optgroup></select>', (string) $input->getControl());
 });
 

--- a/tests/Forms/Controls.RadioList.render.phpt
+++ b/tests/Forms/Controls.RadioList.render.phpt
@@ -64,8 +64,8 @@ test(function () { // translator
 	]);
 	$input->setTranslator(new Translator);
 
-	Assert::same('<label>LABEL</label>', (string) $input->getLabel());
-	Assert::same('<label>ANOTHER LABEL</label>', (string) $input->getLabel('Another label'));
+	Assert::same('<label>Label</label>', (string) $input->getLabel());
+	Assert::same('<label>Another label</label>', (string) $input->getLabel('Another label'));
 	Assert::same('<label for="frm-list-0">SECOND</label>', (string) $input->getLabelPart(0));
 
 	Assert::same('<label><input type="radio" name="list" value="a">FIRST</label><br><label><input type="radio" name="list" value="0">SECOND</label>', (string) $input->getControl());

--- a/tests/Forms/Controls.SelectBox.render.phpt
+++ b/tests/Forms/Controls.SelectBox.render.phpt
@@ -69,8 +69,8 @@ test(function () { // translator & groups
 	])->setPrompt('Prompt');
 	$input->setTranslator(new Translator);
 
-	Assert::same('<label for="frm-list">LABEL</label>', (string) $input->getLabel());
-	Assert::same('<label for="frm-list">ANOTHER LABEL</label>', (string) $input->getLabel('Another label'));
+	Assert::same('<label for="frm-list">Label</label>', (string) $input->getLabel());
+	Assert::same('<label for="frm-list">Another label</label>', (string) $input->getLabel('Another label'));
 	Assert::same('<select name="list" id="frm-list"><option value="">PROMPT</option><option value="a">FIRST</option><optgroup label="GROUP"><option value="0">SECOND</option><option value="1">THIRD</option></optgroup></select>', (string) $input->getControl());
 });
 

--- a/tests/Forms/Controls.TextArea.render.phpt
+++ b/tests/Forms/Controls.TextArea.render.phpt
@@ -45,8 +45,8 @@ test(function () { // translator
 		->setValue('text')
 		->setTranslator(new Translator);
 
-	Assert::same('<label for="frm-text">LABEL</label>', (string) $input->getLabel());
-	Assert::same('<label for="frm-text">ANOTHER LABEL</label>', (string) $input->getLabel('Another label'));
+	Assert::same('<label for="frm-text">Label</label>', (string) $input->getLabel());
+	Assert::same('<label for="frm-text">Another label</label>', (string) $input->getLabel('Another label'));
 	Assert::same('<textarea name="text" placeholder="PLACE" id="frm-text">text</textarea>', (string) $input->getControl());
 });
 

--- a/tests/Forms/Controls.TextInput.render.phpt
+++ b/tests/Forms/Controls.TextInput.render.phpt
@@ -46,8 +46,8 @@ test(function () { // translator
 		->setTranslator(new Translator)
 		->setEmptyValue('xxx');
 
-	Assert::same('<label for="frm-text">LABEL</label>', (string) $input->getLabel());
-	Assert::same('<label for="frm-text">ANOTHER LABEL</label>', (string) $input->getLabel('Another label'));
+	Assert::same('<label for="frm-text">Label</label>', (string) $input->getLabel());
+	Assert::same('<label for="frm-text">Another label</label>', (string) $input->getLabel('Another label'));
 	Assert::same('<input type="text" name="text" placeholder="PLACE" id="frm-text" data-nette-empty-value="XXX" value="text">', (string) $input->getControl());
 });
 

--- a/tests/Forms/Controls.UploadControl.render.phpt
+++ b/tests/Forms/Controls.UploadControl.render.phpt
@@ -49,8 +49,8 @@ test(function () { // Html with translator
 	$input = $form->addUpload('file', 'Label');
 	$input->setTranslator(new Translator);
 
-	Assert::same('<label for="frm-file">LABEL</label>', (string) $input->getLabel());
-	Assert::same('<label for="frm-file">ANOTHER LABEL</label>', (string) $input->getLabel('Another label'));
+	Assert::same('<label for="frm-file">Label</label>', (string) $input->getLabel());
+	Assert::same('<label for="frm-file">Another label</label>', (string) $input->getLabel('Another label'));
 	Assert::same('<label for="frm-file"><b>Another label</b></label>', (string) $input->getLabel(Html::el('b', 'Another label')));
 });
 


### PR DESCRIPTION
This is just idea.

Error messages are since 6451fe0412012c7dac6ad507457d525b67a60bf6 translated by form's translator instead of control's one. It turned out to be the right decision. What about labels? I think that labels should be translated by form's translator too.

Maybe selectbox prompt too, but I am not sure.
