### PR TITLE
netteForms.js: Fixed "Uncaught TypeError: Cannot read property 'tagName' of undefined"

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -44,7 +44,7 @@ Nette.getValue = function(elem) {
 		}
 		return multi ? res : null;
 
-	} else if (!elem.form.elements[elem.name].tagName) { // multi element
+	} else if (elem.name && !elem.form.elements[elem.name].tagName) { // multi element
 		return Nette.getValue(elem.form.elements[elem.name]);
 
 	} else if (elem.type === 'file') {


### PR DESCRIPTION
I get `Uncaught TypeError: Cannot read property 'tagName' of undefined` when I have input without name in the form.

I've made hotfix for that. But sorry, currently without tests.

I can write them in next few days if necessary.