### PR TITLE
netteForms.js: Set validation result CSS classes

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -127,6 +127,7 @@ Nette.validateControl = function(elem, rules, onlyCheck, value) {
 
 		if (rule.condition && success) {
 			if (!Nette.validateControl(elem, rule.rules, onlyCheck, value)) {
+				Nette.markControlInvalid(elem);
 				return false;
 			}
 		} else if (!rule.condition && !success) {
@@ -140,10 +141,32 @@ Nette.validateControl = function(elem, rules, onlyCheck, value) {
 					});
 				Nette.addError(curElem, message);
 			}
+			Nette.markControlInvalid(elem);
 			return false;
 		}
 	}
+	Nette.markControlValid(elem);
 	return true;
+};
+
+
+Nette.markControlValid = function(elem) {
+	Nette.switchClass(elem, 'control-invalid', 'control-valid');
+};
+
+
+Nette.markControlInvalid = function(elem) {
+	Nette.switchClass(elem, 'control-valid', 'control-invalid');
+};
+
+
+Nette.switchClass = function(elem, remove, add) {
+	if (typeof elem.classList === 'undefined') { // not supported in IE < 10 , Opera Mini 8
+		return;
+	}
+
+	elem.classList.remove(remove);
+	elem.classList.add(add);
 };
 
 

--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -151,12 +151,12 @@ Nette.validateControl = function(elem, rules, onlyCheck, value) {
 
 
 Nette.markControlValid = function(elem) {
-	Nette.switchClass(elem, 'control-invalid', 'control-valid');
+	Nette.switchClass(elem, 'nette-control-invalid', 'nette-control-valid');
 };
 
 
 Nette.markControlInvalid = function(elem) {
-	Nette.switchClass(elem, 'control-valid', 'control-invalid');
+	Nette.switchClass(elem, 'nette-control-valid', 'nette-control-invalid');
 };
 
 


### PR DESCRIPTION
Sometimes it's useful visually distinguish valid/invalid inputs.

We use something like the code in this PR.
When we need to use another CSS classes or something absolutely different, it's possible redefine `Nette.markControlValid` and `Nette.markControlInvalid`.

But I don't know if the PR should be accepted.
Also without it we can redefine `Nette.validateControl`, call original backed-up function and handle the result.

So most likely this will be closed without merge.
But I can try it and listen your opinions.
