### PR TITLE
netteForms.js: Show all error messages at once

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -6,6 +6,7 @@
  */
 
 var Nette = Nette || {};
+Nette.errors = [];
 
 /**
  * Attaches a handler to an event for the element.
@@ -182,11 +183,9 @@ Nette.validateForm = function(sender) {
 			continue;
 		}
 
-		if (!Nette.validateControl(elem)) {
-			return false;
-		}
+		Nette.validateControl(elem);
 	}
-	return true;
+	return Nette.showErrors();
 };
 
 
@@ -208,15 +207,60 @@ Nette.isDisabled = function(elem) {
 
 
 /**
- * Display error message.
+ * Adds error message to the queue.
  */
 Nette.addError = function(elem, message) {
-	if (message) {
-		alert(message);
+	Nette.errors.push({
+		elem: elem,
+		message: message
+	});
+};
+
+
+/**
+ * Display error messages.
+ */
+Nette.showErrors = function() {
+	var messages = '';
+	var focusElem;
+
+	for (var i in Nette.errors) {
+		var obj = Nette.errors[i];
+		var elem = obj.elem;
+		var message = obj.message;
+
+		if (!focusElem && elem.focus) {
+			focusElem = elem;
+		}
+
+		if (message) {
+			if (messages) {
+				messages += '\n';
+			}
+			messages += message;
+		}
 	}
-	if (elem.focus) {
-		elem.focus();
+
+	Nette.errors = [];
+	if (messages) {
+		Nette.alert(messages);
+
+		if (focusElem) {
+			focusElem.focus();
+		}
+
+		return false;
 	}
+
+	return true;
+};
+
+
+/**
+ * Shows an alert.
+ */
+Nette.alert = function(message) {
+	alert(message);
 };
 
 

--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -239,7 +239,7 @@ Nette.addError = function(elem, message) {
  * Display error messages.
  */
 Nette.showErrors = function() {
-	var messages = '';
+	var messages = [];
 	var focusElem;
 
 	for (var i in Nette.errors) {
@@ -247,21 +247,18 @@ Nette.showErrors = function() {
 		var elem = obj.elem;
 		var message = obj.message;
 
-		if (!focusElem && elem.focus) {
-			focusElem = elem;
-		}
+		if (messages.indexOf(message) === -1) {
+			messages.push(message);
 
-		if (message) {
-			if (messages) {
-				messages += '\n';
+			if (!focusElem && elem.focus) {
+				focusElem = elem;
 			}
-			messages += message;
 		}
 	}
 
 	Nette.errors = [];
-	if (messages) {
-		Nette.alert(messages);
+	if (messages.length) {
+		Nette.alert(messages.join('\n'));
 
 		if (focusElem) {
 			focusElem.focus();


### PR DESCRIPTION
Nette shows only the first form error. And after user reparation shows the next error etc.

I think show all errors at once is more user friendly.
So I've created PR which adds this behavior.

I think it will be necessary work on it before merge (eg. add options like "show one by one error"/"show all errors at once").

What do you think about that?