### PR TITLE
netteForms.js: Fixed errors for rules on non-present elements

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -111,6 +111,10 @@ Nette.validateControl = function(elem, rules, onlyCheck, value) {
 			op = rule.op.match(/(~)?([^?]+)/),
 			curElem = rule.control ? elem.form.elements[rule.control] : elem;
 
+		if (!curElem) {
+			continue;
+		}
+
 		rule.neg = op[1];
 		rule.op = op[2];
 		rule.condition = !!rule.rules;
@@ -422,6 +426,10 @@ Nette.toggleControl = function(elem, rules, success, firsttime, value) {
 		var rule = rules[id],
 			op = rule.op.match(/(~)?([^?]+)/),
 			curElem = rule.control ? elem.form.elements[rule.control] : elem;
+
+		if (!curElem) {
+			continue;
+		}
 
 		if (success !== false) {
 			rule.neg = op[1];


### PR DESCRIPTION
When I create form and not all of inputs are rendered, JavaScript fails with errors.

So I've added these simple conditions that check if DOM Node exists or not.

Maybe, it should write `console.error` or something like this instead of silent ignore.