### PR TITLE
Update ChoiceControl.php

### DIFF
--- a/src/Forms/Controls/ChoiceControl.php
+++ b/src/Forms/Controls/ChoiceControl.php
@@ -73,7 +73,8 @@ abstract class ChoiceControl extends BaseControl
 	 */
 	public function getValue()
 	{
-		return array_key_exists($this->value, $this->items) ? $this->value : NULL;
+		$items = array_combine(array_keys($this->items), array_values($this->items));
+		return array_key_exists($this->value, $items) ? $this->value : NULL;
 	}
 
 


### PR DESCRIPTION
You should use array_combine due to PHP bug. 

Example:
$obj = new stdClass();
$obj->{"foo"} = "bar";
$obj->{"0"} = "zero";
$arr = (array)$obj;

//foo -- bar
//0 --    {error: undefined index}
foreach ($arr as $key=>$value){
    echo "$key -- " . $arr[$key] . "\n";
}