### PR TITLE
Controls: element prototypes

### DIFF
--- a/src/Forms/Controls/MultiSelectBox.php
+++ b/src/Forms/Controls/MultiSelectBox.php
@@ -18,6 +18,9 @@ class MultiSelectBox extends MultiChoiceControl
 	/** @var array of option / optgroup */
 	private $options = [];
 
+	/** @var array */
+	private $optionAttributes = [];
+
 
 	public function __construct($label = NULL, array $items = NULL)
 	{
@@ -64,11 +67,22 @@ class MultiSelectBox extends MultiChoiceControl
 
 		return Nette\Forms\Helpers::createSelectBox(
 			$items,
-			[
+			array_merge($this->optionAttributes, [
 				'selected?' => $this->value,
 				'disabled:' => is_array($this->disabled) ? $this->disabled : NULL,
-			]
+			])
 		)->addAttributes(parent::getControl()->attrs)->multiple(TRUE);
+	}
+
+
+	/**
+	 * @param array
+	 * @return self
+	 */
+	public function addOptionAttributes(array $attributes)
+	{
+		$this->optionAttributes = array_merge($this->optionAttributes, $attributes);
+		return $this;
 	}
 
 }

--- a/src/Forms/Controls/SelectBox.php
+++ b/src/Forms/Controls/SelectBox.php
@@ -24,6 +24,9 @@ class SelectBox extends ChoiceControl
 	/** @var mixed */
 	private $prompt = FALSE;
 
+	/** @var array */
+	private $optionAttributes = [];
+
 
 	public function __construct($label = NULL, array $items = NULL)
 	{
@@ -92,11 +95,22 @@ class SelectBox extends ChoiceControl
 
 		return Nette\Forms\Helpers::createSelectBox(
 			$items,
-			[
+			array_merge($this->optionAttributes, [
 				'selected?' => $this->value,
 				'disabled:' => is_array($this->disabled) ? $this->disabled : NULL,
-			]
+			])
 		)->addAttributes(parent::getControl()->attrs);
+	}
+
+
+	/**
+	 * @param array
+	 * @return self
+	 */
+	public function addOptionAttributes(array $attributes)
+	{
+		$this->optionAttributes = array_merge($this->optionAttributes, $attributes);
+		return $this;
 	}
 
 

--- a/tests/Forms/Controls.MultiSelectBox.render.phpt
+++ b/tests/Forms/Controls.MultiSelectBox.render.phpt
@@ -131,3 +131,14 @@ test(function () { // rendering options
 	$input->getControl();
 	Assert::true($input->getOption('rendered'));
 });
+
+
+test(function() {
+	$form = new Form;
+	$input = $form->addMultiSelect('list', 'Label', [
+		1 => 'First',
+		2 => 'Second',
+	]);
+	$input->addOptionAttributes(['data-foo:' => [1 => 'a', 2 => 'b']]);
+	Assert::same('<select name="list[]" id="frm-list" multiple><option value="1" data-foo="a">First</option><option value="2" data-foo="b">Second</option></select>', (string) $input->getControl());
+});

--- a/tests/Forms/Controls.SelectBox.render.phpt
+++ b/tests/Forms/Controls.SelectBox.render.phpt
@@ -131,3 +131,14 @@ test(function () { // rendering options
 	$input->getControl();
 	Assert::true($input->getOption('rendered'));
 });
+
+
+test(function() {
+	$form = new Form;
+	$input = $form->addSelect('list', 'Label', [
+		1 => 'First',
+		2 => 'Second',
+	]);
+	$input->addOptionAttributes(['data-foo:' => [1 => 'a', 2 => 'b']]);
+	Assert::same('<select name="list" id="frm-list"><option value="1" data-foo="a">First</option><option value="2" data-foo="b">Second</option></select>', (string) $input->getControl());
+});


### PR DESCRIPTION
CheckBoxList item label prototype:
- BC break: attributes of main label are ignored for individual item labels
- fixes consistency - radiolist already has itemLabelPrototype
- http://forum.nette.org/cs/22457-checkboxlist-a-pridani-atributu-jako-je-treba-class-nebo-data-atribut-k-jednotlivym-checkboxum-v-listu (see my comment there)

SelectBox and MultiselectBox item prototype
- BC break: no
- simplifies http://forum.nette.org/cs/22874-select-a-options-data-attributy