### PR TITLE
Fix: validate() on forms where is attached non-form component causes error

### DIFF
--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -20,7 +20,7 @@ use Nette;
  * @property-read \ArrayIterator $controls
  * @property-read Form $form
  */
-class Container extends Nette\ComponentModel\Container implements \ArrayAccess
+class Container extends Nette\ComponentModel\Container implements IValidatable, \ArrayAccess
 {
 	/** @var callable[]  function (Container $sender); Occurs when the form is validated */
 	public $onValidate;
@@ -134,7 +134,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	 */
 	public function validate(array $controls = NULL)
 	{
-		foreach ($controls === NULL ? $this->getComponents() : $controls as $control) {
+		foreach ($controls === NULL ? $this->getComponents(FALSE, 'Nette\Forms\IValidatable') : $controls as $control) {
 			$control->validate();
 		}
 		foreach ($this->onValidate ?: [] as $handler) {

--- a/src/Forms/IControl.php
+++ b/src/Forms/IControl.php
@@ -11,7 +11,7 @@ namespace Nette\Forms;
 /**
  * Defines method that must be implemented to allow a component to act like a form control.
  */
-interface IControl
+interface IControl extends IValidatable
 {
 
 	/**
@@ -26,11 +26,6 @@ interface IControl
 	 * @return mixed
 	 */
 	function getValue();
-
-	/**
-	 * @return void
-	 */
-	function validate();
 
 	/**
 	 * Returns errors corresponding to control.

--- a/src/Forms/IValidatable.php
+++ b/src/Forms/IValidatable.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Forms;
+
+use Nette;
+
+
+/**
+ * Defines method that must be implemented to allow a component to be validatable in form.
+ *
+ * @author     Ondrej Vlach
+ */
+interface IValidatable
+{
+	/**
+	 * @return void
+	 */
+	function validate();
+}


### PR DESCRIPTION
- bugfix
- documentation - not needed
- BC break - no

validate() on forms where is attached non-form component causes error - older nette/form using getControls() method where is interface checking.

Now this is not possible, so i create special IValidatable interface which marks controls and container as validatable and checking it.
