### PR TITLE
ControlGroup: allows Container inside ControlGroup

### DIFF
--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -426,6 +426,9 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	{
 		$control = new self;
 		$control->currentGroup = $this->currentGroup;
+		if ($this->currentGroup !== NULL) {
+			$this->currentGroup->add($control);
+		}
 		return $this[$name] = $control;
 	}
 

--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -191,7 +191,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	public function addComponent(Nette\ComponentModel\IComponent $component, $name, $insertBefore = NULL)
 	{
 		parent::addComponent($component, $name, $insertBefore);
-		if ($this->currentGroup !== NULL && $component instanceof IControl) {
+		if ($this->currentGroup !== NULL) {
 			$this->currentGroup->add($component);
 		}
 		return $this;

--- a/src/Forms/ControlGroup.php
+++ b/src/Forms/ControlGroup.php
@@ -37,6 +37,10 @@ class ControlGroup extends Nette\Object
 			if ($item instanceof IControl) {
 				$this->controls->attach($item);
 
+			} elseif ($item instanceof Container) {
+				foreach ($item->getComponents() as $component) {
+					$this->add($component);
+				}
 			} elseif ($item instanceof \Traversable || is_array($item)) {
 				foreach ($item as $control) {
 					$this->controls->attach($control);

--- a/tests/Forms/ControlGroup.phpt
+++ b/tests/Forms/ControlGroup.phpt
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Test: Nette\Forms\ControlGroup.
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+function getContainer() {
+	$container = new \Nette\Forms\Container();
+	$container->addText('street', 'Street');
+	$container->addText('town', 'Town');
+	return $container;
+}
+
+$form = new Nette\Forms\Form;
+
+
+// controls only
+$group1 = $form->addGroup();
+$form->addText('name', 'Name');
+$form->addText('surname', 'Surname');
+
+Assert::same($group1, $form->getGroup(0));
+Assert::true($form->getGroup(0) instanceof \Nette\Forms\ControlGroup);
+Assert::equal(2, count($group1->getControls()));
+Assert::equal(array($form['name'], $form['surname']), $group1->getControls());
+
+
+// container only
+$group2 = $form->addGroup('Address');
+$form->addComponent(getContainer(), 'address');
+
+Assert::same($group2, $form->getGroup('Address'));
+Assert::true($form->getGroup('Address') instanceof \Nette\Forms\ControlGroup);
+Assert::equal(2, count($group2->getControls()));
+Assert::equal(array($form['address']['street'], $form['address']['town']), $group2->getControls());
+
+
+// nested containers
+$group3 = $form->addGroup('Nested');
+$container = getContainer();
+$container->addComponent(getContainer(), 'child');
+$form->addComponent($container, 'parent');
+
+Assert::equal(4, count($group3->getControls()));
+Assert::equal(array($form['parent']['street'], $form['parent']['town'], $form['parent']['child']['street'], $form['parent']['child']['town']), $group3->getControls());
+
+
+// container and controls
+$group4 = $form->addGroup('Mix');
+$form->addText('foo');
+$form->addComponent(getContainer(), 'mix');
+$form->addText('bar');
+
+Assert::equal(4, count($group4->getControls()));
+Assert::equal(array($form['foo'], $form['mix']['street'], $form['mix']['town'], $form['bar']), $group4->getControls());
+
+
+Assert::equal(4, count($form->getGroups()));

--- a/tests/Forms/ControlGroup.phpt
+++ b/tests/Forms/ControlGroup.phpt
@@ -19,44 +19,63 @@ $form = new Nette\Forms\Form;
 
 
 // controls only
-$group1 = $form->addGroup();
+$group = $form->addGroup();
 $form->addText('name', 'Name');
 $form->addText('surname', 'Surname');
 
-Assert::same($group1, $form->getGroup(0));
+Assert::same($group, $form->getGroup(0));
 Assert::true($form->getGroup(0) instanceof \Nette\Forms\ControlGroup);
-Assert::equal(2, count($group1->getControls()));
-Assert::equal(array($form['name'], $form['surname']), $group1->getControls());
+Assert::equal(2, count($group->getControls()));
+Assert::equal(array($form['name'], $form['surname']), $group->getControls());
 
 
 // container only
-$group2 = $form->addGroup('Address');
+$group = $form->addGroup('Address');
 $form->addComponent(getContainer(), 'address');
 
-Assert::same($group2, $form->getGroup('Address'));
+Assert::same($group, $form->getGroup('Address'));
 Assert::true($form->getGroup('Address') instanceof \Nette\Forms\ControlGroup);
-Assert::equal(2, count($group2->getControls()));
-Assert::equal(array($form['address']['street'], $form['address']['town']), $group2->getControls());
+Assert::equal(2, count($group->getControls()));
+Assert::equal(array($form['address']['street'], $form['address']['town']), $group->getControls());
 
 
 // nested containers
-$group3 = $form->addGroup('Nested');
+$group = $form->addGroup('Nested');
 $container = getContainer();
 $container->addComponent(getContainer(), 'child');
 $form->addComponent($container, 'parent');
 
-Assert::equal(4, count($group3->getControls()));
-Assert::equal(array($form['parent']['street'], $form['parent']['town'], $form['parent']['child']['street'], $form['parent']['child']['town']), $group3->getControls());
+Assert::equal(4, count($group->getControls()));
+Assert::equal(array($form['parent']['street'], $form['parent']['town'], $form['parent']['child']['street'], $form['parent']['child']['town']), $group->getControls());
 
 
 // container and controls
-$group4 = $form->addGroup('Mix');
+$group = $form->addGroup('Mix');
 $form->addText('foo');
 $form->addComponent(getContainer(), 'mix');
 $form->addText('bar');
 
-Assert::equal(4, count($group4->getControls()));
-Assert::equal(array($form['foo'], $form['mix']['street'], $form['mix']['town'], $form['bar']), $group4->getControls());
+Assert::equal(4, count($group->getControls()));
+Assert::equal(array($form['foo'], $form['mix']['street'], $form['mix']['town'], $form['bar']), $group->getControls());
 
 
-Assert::equal(4, count($form->getGroups()));
+// addContainer
+$group = $form->addGroup('Container');
+$container = $form->addContainer('container');
+$container->addText('text1');
+$container->addText('text2');
+
+Assert::equal(2, count($group->getControls()));
+Assert::equal(array($form['container']['text1'], $form['container']['text2']), $group->getControls());
+
+
+// addContainer recursive
+$group = $form->addGroup('Container');
+$container1 = $form->addContainer('outer');
+$container2 = $container1->addContainer('inner');
+$container2->addText('text');
+
+Assert::equal(1, count($group->getControls()));
+Assert::equal(array($form['outer']['inner']['text']), $group->getControls());
+
+Assert::equal(6, count($form->getGroups()));

--- a/tests/Forms/Forms.renderer.5.expect
+++ b/tests/Forms/Forms.renderer.5.expect
@@ -1,0 +1,123 @@
+<form action="" method="post">
+
+<fieldset>
+<table>
+<tr>
+	<th><label for="frm-name">Name</label></th>
+
+	<td><input type="text" name="name" id="frm-name" class="text"></td>
+</tr>
+
+<tr>
+	<th><label for="frm-surname">Surname</label></th>
+
+	<td><input type="text" name="surname" id="frm-surname" class="text"></td>
+</tr>
+</table>
+</fieldset>
+
+<fieldset>
+<legend>Address</legend>
+
+<table>
+<tr>
+	<th><label for="frm-address-street">Street</label></th>
+
+	<td><input type="text" name="address[street]" id="frm-address-street" class="text"></td>
+</tr>
+
+<tr>
+	<th><label for="frm-address-town">Town</label></th>
+
+	<td><input type="text" name="address[town]" id="frm-address-town" class="text"></td>
+</tr>
+
+<tr>
+	<th><label for="frm-address-country">Country</label></th>
+
+	<td><input type="text" name="address[country]" id="frm-address-country" class="text"></td>
+</tr>
+</table>
+</fieldset>
+
+<fieldset>
+<legend>Shipping Address</legend>
+
+<table>
+<tr>
+	<th><label for="frm-shippingAddress-street">Street</label></th>
+
+	<td><input type="text" name="shippingAddress[street]" id="frm-shippingAddress-street" class="text"></td>
+</tr>
+
+<tr>
+	<th><label for="frm-shippingAddress-town">Town</label></th>
+
+	<td><input type="text" name="shippingAddress[town]" id="frm-shippingAddress-town" class="text"></td>
+</tr>
+
+<tr>
+	<th><label for="frm-shippingAddress-country">Country</label></th>
+
+	<td><input type="text" name="shippingAddress[country]" id="frm-shippingAddress-country" class="text"></td>
+</tr>
+
+<tr>
+	<th><label for="frm-note">Note</label></th>
+
+	<td><textarea name="note" id="frm-note"></textarea></td>
+</tr>
+</table>
+</fieldset>
+
+<fieldset>
+<legend>Nested</legend>
+
+<table>
+<tr>
+	<th><label for="frm-parent-street">Street</label></th>
+
+	<td><input type="text" name="parent[street]" id="frm-parent-street" class="text"></td>
+</tr>
+
+<tr>
+	<th><label for="frm-parent-town">Town</label></th>
+
+	<td><input type="text" name="parent[town]" id="frm-parent-town" class="text"></td>
+</tr>
+
+<tr>
+	<th><label for="frm-parent-country">Country</label></th>
+
+	<td><input type="text" name="parent[country]" id="frm-parent-country" class="text"></td>
+</tr>
+
+<tr>
+	<th><label for="frm-parent-child-street">Street</label></th>
+
+	<td><input type="text" name="parent[child][street]" id="frm-parent-child-street" class="text"></td>
+</tr>
+
+<tr>
+	<th><label for="frm-parent-child-town">Town</label></th>
+
+	<td><input type="text" name="parent[child][town]" id="frm-parent-child-town" class="text"></td>
+</tr>
+
+<tr>
+	<th><label for="frm-parent-child-country">Country</label></th>
+
+	<td><input type="text" name="parent[child][country]" id="frm-parent-child-country" class="text"></td>
+</tr>
+</table>
+</fieldset>
+
+<table>
+<tr>
+	<th></th>
+
+	<td><input type="submit" name="_submit" value="Order" class="button"></td>
+</tr>
+</table>
+
+</form>

--- a/tests/Forms/Forms.renderer.5.phpt
+++ b/tests/Forms/Forms.renderer.5.phpt
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Test: Nette\Forms default rendering containers inside groups.
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+function getContainer() {
+	$container = new \Nette\Forms\Container();
+	$container->addText('street', 'Street');
+	$container->addText('town', 'Town');
+	$container->addText('country', 'Country');
+	return $container;
+}
+
+$form = new Nette\Forms\Form;
+
+// controls only
+$form->addGroup();
+$form->addText('name', 'Name');
+$form->addText('surname', 'Surname');
+
+// container only
+$form->addGroup('Address');
+$form->addComponent(getContainer(), 'address');
+
+// container + control
+$form->addGroup('Shipping Address');
+$form->addComponent(getContainer(), 'shippingAddress');
+$form->addTextArea('note', 'Note');
+
+// nested containers
+$form->addGroup('Nested');
+$container = getContainer();
+$container->addComponent(getContainer(), 'child');
+$form->addComponent($container, 'parent');
+
+$form->setCurrentGroup();
+$form->addSubmit('submit', 'Order');
+
+$form->fireEvents();
+
+Assert::matchFile(__DIR__ . '/Forms.renderer.5.expect', $form->__toString(TRUE));


### PR DESCRIPTION
In current state, `$form->addComponent($container, 'name')` won't be added into any group.

This pull request adds support for such containers (including nested containers).