### PR TITLE
addError() is able to translate

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -488,6 +488,9 @@ class Form extends Container implements Nette\Utils\IHtmlString
 	 */
 	public function addError($message)
 	{
+		if($this->translator) {
+			$message = $this->translator->translate($message);
+		}
 		$this->errors[] = $message;
 	}
 

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -488,7 +488,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 	 */
 	public function addError($message)
 	{
-		if($this->translator) {
+		if ($this->translator) {
 			$message = $this->translator->translate($message);
 		}
 		$this->errors[] = $message;


### PR DESCRIPTION
Is there a reason why addError does not translate?