### PR TITLE
UploadControl isFilled vs isOk

### DIFF
--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -39,6 +39,7 @@ class Validator extends Nette\Object
 		Form::MIME_TYPE => 'The uploaded file is not in the expected format.',
 		Form::IMAGE => 'The uploaded file must be image in format JPEG, GIF or PNG.',
 		Controls\SelectBox::VALID => 'Please select a valid option.',
+		Controls\UploadControl::VALID => 'An error occured during file upload.',
 	];
 
 

--- a/tests/Forms/Controls.UploadControl.loadData.phpt
+++ b/tests/Forms/Controls.UploadControl.loadData.phpt
@@ -52,6 +52,13 @@ $_FILES = [
 		'size' => [NULL],
 	],
 	'invalid2' => '',
+	'partial' => [
+		'name' => 'license.txt',
+		'type' => 'text/plain',
+		'tmp_name' => __DIR__ . '/files/logo.gif',
+		'error' => UPLOAD_ERR_PARTIAL,
+		'size' => 3013,
+	],
 ];
 
 
@@ -68,6 +75,7 @@ test(function () {
 		'error' => 0,
 	]), $input->getValue());
 	Assert::true($input->isFilled());
+	Assert::true($input->isOk());
 });
 
 
@@ -84,6 +92,7 @@ test(function () { // container
 		'error' => 0,
 	]), $input->getValue());
 	Assert::true($input->isFilled());
+	Assert::true($input->isOk());
 });
 
 
@@ -106,6 +115,7 @@ test(function () { // multiple (in container)
 		'error' => 0,
 	])], $input->getValue());
 	Assert::true($input->isFilled());
+	Assert::true($input->isOk());
 });
 
 
@@ -117,6 +127,7 @@ test(function () { // missing data
 	Assert::false($form->isValid());
 	Assert::equal([], $input->getValue());
 	Assert::false($input->isFilled());
+	Assert::false($input->isOk());
 });
 
 
@@ -128,6 +139,7 @@ test(function () { // empty data
 	Assert::false($form->isValid());
 	Assert::equal(new FileUpload([]), $input->getValue());
 	Assert::false($input->isFilled());
+	Assert::false($input->isOk());
 });
 
 
@@ -138,6 +150,7 @@ test(function () { // malformed data
 	Assert::true($form->isValid());
 	Assert::equal(new FileUpload([]), $input->getValue());
 	Assert::false($input->isFilled());
+	Assert::false($input->isOk());
 
 	$form = new Form;
 	$input = $form->addUpload('invalid2');
@@ -145,6 +158,7 @@ test(function () { // malformed data
 	Assert::true($form->isValid());
 	Assert::equal(new FileUpload([]), $input->getValue());
 	Assert::false($input->isFilled());
+	Assert::false($input->isOk());
 
 	$form = new Form;
 	$input = $form->addMultiUpload('avatar');
@@ -152,6 +166,7 @@ test(function () { // malformed data
 	Assert::true($form->isValid());
 	Assert::equal([], $input->getValue());
 	Assert::false($input->isFilled());
+	Assert::false($input->isOk());
 
 	$form = new Form;
 	$input = $form->addContainer('multiple')->addUpload('avatar');
@@ -159,6 +174,25 @@ test(function () { // malformed data
 	Assert::true($form->isValid());
 	Assert::equal(new FileUpload([]), $input->getValue());
 	Assert::false($input->isFilled());
+	Assert::false($input->isOk());
+});
+
+
+test(function () { // partial uploaded (error)
+	$form = new Form;
+	$input = $form->addUpload('partial')
+		->setRequired();
+
+	Assert::false($form->isValid());
+	Assert::equal(new FileUpload([
+		'name' => 'license.txt',
+		'type' => '',
+		'tmp_name' => __DIR__ . '/files/logo.gif',
+		'error' => UPLOAD_ERR_PARTIAL,
+		'size' => 3013,
+	]), $input->getValue());
+	Assert::true($input->isFilled());
+	Assert::false($input->isOk());
 });
 
 


### PR DESCRIPTION
Distinguish error and filling FileUpload differently
When a file is uploaded with error:
Old solution: isOk() == FALSE, isFilled() == FALSE
New solution: isOk() == FALSE, isFilled() == TRUE

- bugfix
- issues - none
- documentation - needed: https://forum.nette.org/en/25661-uploadcontrol-isfilled-vs-isok
- BC break - no