### PR TITLE
Rename Html:add() to Html:addHtml() to follow nette/utils#111

### DIFF
--- a/src/Forms/Rendering/DefaultFormRenderer.php
+++ b/src/Forms/Rendering/DefaultFormRenderer.php
@@ -224,11 +224,11 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 		foreach ($errors as $error) {
 			$item = clone $item;
 			if ($error instanceof Html) {
-				$item->add($error);
+				$item->addHtml($error);
 			} else {
 				$item->setText($error);
 			}
-			$container->add($item);
+			$container->addHtml($item);
 		}
 		return "\n" . $container->render($control ? 1 : 0);
 	}
@@ -262,7 +262,7 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 
 			$text = $group->getOption('label');
 			if ($text instanceof Html) {
-				$s .= $this->getWrapper('group label')->add($text);
+				$s .= $this->getWrapper('group label')->addHtml($text);
 
 			} elseif (is_string($text)) {
 				if ($translator !== NULL) {
@@ -322,15 +322,15 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 
 			} else {
 				if ($buttons) {
-					$container->add($this->renderPairMulti($buttons));
+					$container->addHtml($this->renderPairMulti($buttons));
 					$buttons = NULL;
 				}
-				$container->add($this->renderPair($control));
+				$container->addHtml($this->renderPair($control));
 			}
 		}
 
 		if ($buttons) {
-			$container->add($this->renderPairMulti($buttons));
+			$container->addHtml($this->renderPairMulti($buttons));
 		}
 
 		$s = '';
@@ -349,8 +349,8 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 	public function renderPair(Nette\Forms\IControl $control)
 	{
 		$pair = $this->getWrapper('pair container');
-		$pair->add($this->renderLabel($control));
-		$pair->add($this->renderControl($control));
+		$pair->addHtml($this->renderLabel($control));
+		$pair->addHtml($this->renderControl($control));
 		$pair->class($this->getValue($control->isRequired() ? 'pair .required' : 'pair .optional'), TRUE);
 		$pair->class($control->hasErrors() ? $this->getValue('pair .error') : NULL, TRUE);
 		$pair->class($control->getOption('class'), TRUE);
@@ -393,8 +393,8 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 			$s[] = $el . $description;
 		}
 		$pair = $this->getWrapper('pair container');
-		$pair->add($this->renderLabel($control));
-		$pair->add($this->getWrapper('control container')->setHtml(implode(' ', $s)));
+		$pair->addHtml($this->renderLabel($control));
+		$pair->addHtml($this->getWrapper('control container')->setHtml(implode(' ', $s)));
 		return $pair->render(0);
 	}
 
@@ -408,7 +408,7 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 		$suffix = $this->getValue('label suffix') . ($control->isRequired() ? $this->getValue('label requiredsuffix') : '');
 		$label = $control->getLabel();
 		if ($label instanceof Html) {
-			$label->add($suffix);
+			$label->addHtml($suffix);
 			if ($control->isRequired()) {
 				$label->class($this->getValue('control .required'), TRUE);
 			}


### PR DESCRIPTION
nette/utils#111 has renamed `Html::add()` to `Html::addHtml()`, this is a followup pull request to use the new name in nette/forms