### PR TITLE
Trigger error from Rules::check only for Form::REQUIRED

### DIFF
--- a/src/Forms/Rules.php
+++ b/src/Forms/Rules.php
@@ -266,7 +266,7 @@ class Rules implements \IteratorAggregate
 				if ($rule->branch->check() === TRUE) {
 					return TRUE;
 				}
-			} else {
+			} else if ($rule->validator === Form::REQUIRED) {
 				trigger_error("Missing setRequired(TRUE | FALSE) on field '{$rule->control->getName()}' in form '{$rule->control->getForm()->getName()}'.", E_USER_WARNING);
 				return TRUE;
 			}

--- a/tests/Forms/Forms.userValidator.phpt
+++ b/tests/Forms/Forms.userValidator.phpt
@@ -32,4 +32,6 @@ foreach ($datasets as $case) {
 
 	$control->setValue($case[0])->validate();
 	Assert::same($case[1], $control->getErrors());
+
+	$form->fireRenderEvents();
 }


### PR DESCRIPTION
Hi it is possible fix wrong-triggering error related to setRequired(TRUE | FALSE) by this more strict code?

This is happening for example for own validation callback.