### PR TITLE
Fixed Nette.showFormErrors()

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -281,7 +281,7 @@ Nette.showFormErrors = function(form, errors) {
 	var messages = [],
 		focusElem;
 
-	for (var i in errors) {
+	for (var i = 0; i < errors.length; i++) {
 		var elem = errors[i].element,
 			message = errors[i].message;
 


### PR DESCRIPTION
It triggers error `'focus' má hodnotu null nebo není objekt.` in IE8 because `in` iterates over all properties, even `indexOf` etc.