### PR TITLE
Fixed click event on body in IE8

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -672,7 +672,7 @@ Nette.initOnLoad = function() {
 		}
 
 		Nette.addEvent(document.body, 'click', function(e) {
-			var target = e.target || e.srcElement;
+			var target = e ? e.target : window.event.srcElement;
 			if (target.form && target.type in {submit: 1, image: 1}) {
 				target.form['nette-submittedBy'] = target;
 			}


### PR DESCRIPTION
IE8 uses a global event object, instead of sending parameter in callback function.