### PR TITLE
we can't validate form without throw alert errors

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -202,7 +202,7 @@ Nette.validateControl = function(elem, rules, onlyCheck, value, emptyOptional) {
 /**
  * Validates whole form.
  */
-Nette.validateForm = function(sender) {
+Nette.validateForm = function(sender, onlyCheck) {
 	var form = sender.form || sender,
 		scope = false;
 
@@ -237,7 +237,11 @@ Nette.validateForm = function(sender) {
 			continue;
 		}
 
-		if (!Nette.validateControl(elem) && !Nette.formErrors.length) {
+		if(typeof onlyCheck === 'undefined') {
+			var onlyCheck = false;
+		}
+
+		if (!Nette.validateControl(elem, null, onlyCheck) && !Nette.formErrors.length) {
 			return false;
 		}
 	}


### PR DESCRIPTION
This feature can be used when i want to know, that form is valid, so i can run spinner or something else, while page is loading. 