### PR TITLE
Cannot use range() to validate min/max

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -480,7 +480,7 @@ Nette.validators = {
 				return null;
 			}
 		}
-		return Nette.validators.range(elem, [arg, null], val);
+		return arg === null || parseFloat(val) >= arg;
 	},
 
 	max: function(elem, arg, val) {
@@ -491,7 +491,7 @@ Nette.validators = {
 				return null;
 			}
 		}
-		return Nette.validators.range(elem, [null, arg], val);
+		return arg === null || parseFloat(val) <= arg;
 	},
 
 	range: function(elem, arg, val) {


### PR DESCRIPTION
When there is different error message for min/max, then checking min or max via `range()` can cause it fails during `min` validation for `max` invalidity (and vice versa) - due to `rangeUnderflow`/`rangeOverflow`. Then wrong error message may be shown.