### PR TITLE
Fixed issue with button type=submit that contains html

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -682,7 +682,7 @@ Nette.initOnLoad = function() {
 			while(target && !(target.type in {submit: 1, image: 1} || target.form)){
 				target = target.parentNode;
 			}
-			if (target.form && target.type in {submit: 1, image: 1}) {
+			if (target && target.form && target.type in {submit: 1, image: 1}) {
 				target.form['nette-submittedBy'] = target;
 			}
 		});

--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -679,10 +679,10 @@ Nette.initOnLoad = function() {
 
 		Nette.addEvent(document.body, 'click', function(e) {
 			var target = e.target || e.srcElement;
-			while(target && !(target.type in {submit: 1, image: 1} || target.form)){
+			while(target.parentNode && !(target.type in {submit: 1, image: 1} || target.form)){
 				target = target.parentNode;
 			}
-			if (target && target.form && target.type in {submit: 1, image: 1}) {
+			if (target.form && target.type in {submit: 1, image: 1}) {
 				target.form['nette-submittedBy'] = target;
 			}
 		});

--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -679,6 +679,9 @@ Nette.initOnLoad = function() {
 
 		Nette.addEvent(document.body, 'click', function(e) {
 			var target = e.target || e.srcElement;
+			while(target && !(target.type in {submit: 1, image: 1} || target.form)){
+				target = target.parentNode;
+			}
 			if (target.form && target.type in {submit: 1, image: 1}) {
 				target.form['nette-submittedBy'] = target;
 			}


### PR DESCRIPTION
If button have some HTML inside, like `<i class="icon icon-send"></i>` and user click on `<i>` instead of button, nette thinks there is no submittedBy button, that is not true, as `<i>` have parent button element, so we need to go thru DOM tree, to check if the button isnt parent of clicked element.