### PR TITLE
For number type, use a user-defined validation text instead of "Please enter a valid value."

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -187,6 +187,15 @@ Nette.validateControl = function(elem, rules, onlyCheck, value, emptyOptional) {
 				Nette.addError(curElem, message);
 			}
 			return false;
+		} else if (elem.type === 'number' && !elem.validity.valid) {
+			if (!onlyCheck) {
+				var arr = Nette.isArray(rule.arg) ? rule.arg : [rule.arg],
+					message = rule.msg.replace(/%(value|\d+)/g, function(foo, m) {
+						return Nette.getValue(m === 'value' ? curElem : elem.form.elements.namedItem(arr[m].control));
+					});
+				Nette.addError(curElem, message);
+			}
+			return false;
 		}
 	}
 


### PR DESCRIPTION
The JS library always uses a hardcoded error text: "Please enter a valid value." if a type="number" field is misfilled.
It should only fall back to the hardcoded text if no error message has been defined.

- bugfix
- issues: none
- documentation: not needed
- BC break: no
