### PR TITLE
Added option to disable translation of select options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,20 @@ php:
     - 7.0
     - 7.1
 
+env:
 matrix:
     include:
         - php: 5.6
           env: dependencies="--prefer-lowest --prefer-stable"
+        - php: 7.0
+          env: coverage=on
+
+    allow_failures:
+        - php: 7.0
+          env: coverage=on
 
 script:
-    - vendor/bin/tester tests -s -c tests/php-unix.ini $coverage
+    - vendor/bin/tester tests -s -c tests/php-unix.ini $coverageArgs
     - php temp/code-checker/src/code-checker.php --short-arrays -i netteForms
     - if [ $TRAVIS_PHP_VERSION == "7.0" ]; then grunt --gruntfile=tests/netteForms/Gruntfile.js test; fi
 
@@ -23,12 +30,12 @@ before_script:
     - travis_retry composer update --no-interaction --prefer-dist $dependencies
     - travis_retry composer create-project nette/code-checker temp/code-checker ~2.5 --no-interaction
     - if [ $TRAVIS_PHP_VERSION == "7.0" ]; then npm install -g grunt-cli; cd tests/netteForms; npm install; cd ../..; fi
-    - if [ $TRAVIS_PHP_VERSION == "7.0" ]; then coverage="-p phpdbg --coverage ./coverage.xml --coverage-src ./src"; fi
+    - if [ "$coverage" == "on" ]; then coverageArgs="-p phpdbg --coverage ./coverage.xml --coverage-src ./src"; fi
 
 after_script:
     # Report Code Coverage
     - >
-      if [ "$coverage" != "" ]; then
+      if [ "$coverage" == "on" ]; then
       wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar
       && php coveralls.phar --verbose --config tests/.coveralls.yml
       || true; fi

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
 	],
 	"require": {
 		"php": ">=5.6.0",
-		"nette/component-model": "~2.3",
-		"nette/http": "~2.2",
-		"nette/utils": "~2.4"
+		"nette/component-model": "^2.3",
+		"nette/http": "^2.2 || ~3.0.0",
+		"nette/utils": "^2.4"
 	},
 	"require-dev": {
-		"nette/di": "~2.4",
-		"nette/tester": "~2.0",
-		"latte/latte": "~2.4",
+		"nette/di": "^2.4 || ~3.0.0",
+		"nette/tester": "^2.0",
+		"latte/latte": "^2.4.1",
 		"tracy/tracy": "^2.4"
 	},
 	"conflict": {

--- a/examples/custom-control.php
+++ b/examples/custom-control.php
@@ -51,7 +51,7 @@ class DateInput extends Nette\Forms\Controls\BaseControl
 	public function getValue()
 	{
 		return self::validateDate($this)
-			? (new DateTimeImmutable)->setDate($this->year, $this->month, $this->day)->setTime(0, 0)
+			? (new DateTimeImmutable)->setDate((int) $this->year, (int) $this->month, (int) $this->day)->setTime(0, 0)
 			: NULL;
 	}
 
@@ -110,7 +110,7 @@ class DateInput extends Nette\Forms\Controls\BaseControl
 		return ctype_digit($control->day)
 			&& ctype_digit($control->month)
 			&& ctype_digit($control->year)
-			&& checkdate($control->month, $control->day, $control->year);
+			&& checkdate((int) $control->month, (int) $control->day, (int) $control->year);
 	}
 
 }

--- a/src/Bridges/FormsLatte/Runtime.php
+++ b/src/Bridges/FormsLatte/Runtime.php
@@ -49,7 +49,7 @@ class Runtime
 	{
 		$s = '';
 		if ($form->isMethod('get')) {
-			foreach (preg_split('#[;&]#', parse_url($form->getElementPrototype()->action, PHP_URL_QUERY), NULL, PREG_SPLIT_NO_EMPTY) as $param) {
+			foreach (preg_split('#[;&]#', (string) parse_url($form->getElementPrototype()->action, PHP_URL_QUERY), -1, PREG_SPLIT_NO_EMPTY) as $param) {
 				$parts = explode('=', $param, 2);
 				$name = urldecode($parts[0]);
 				if (!isset($form[$name])) {

--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -218,12 +218,12 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Returns form.
-	 * @param  bool   throw exception if form doesn't exist?
+	 * @param  bool
 	 * @return Form
 	 */
-	public function getForm($need = TRUE)
+	public function getForm($throw = TRUE)
 	{
-		return $this->lookup(Form::class, $need);
+		return $this->lookup(Form::class, $throw);
 	}
 
 

--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -34,7 +34,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Fill-in with default values.
-	 * @param  array|\Traversable  values used to fill the form
+	 * @param  iterable  values used to fill the form
 	 * @param  bool     erase other default values?
 	 * @return static
 	 */
@@ -50,7 +50,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Fill-in with values.
-	 * @param  array|\Traversable  values used to fill the form
+	 * @param  iterable  values used to fill the form
 	 * @param  bool     erase other controls?
 	 * @return static
 	 * @internal

--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -14,15 +14,15 @@ use Nette;
  * Container for form controls.
  *
  * @property   Nette\Utils\ArrayHash $values
- * @property-read \ArrayIterator $controls
- * @property-read Form $form
+ * @property-read \Iterator $controls
+ * @property-read Form|NULL $form
  */
 class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 {
 	/** @var callable[]  function (Container $sender); Occurs when the form is validated */
 	public $onValidate;
 
-	/** @var ControlGroup */
+	/** @var ControlGroup|NULL */
 	protected $currentGroup;
 
 	/** @var bool */
@@ -34,8 +34,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Fill-in with default values.
-	 * @param  iterable  values used to fill the form
-	 * @param  bool     erase other default values?
+	 * @param  iterable
+	 * @param  bool
 	 * @return static
 	 */
 	public function setDefaults($values, $erase = FALSE)
@@ -50,8 +50,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Fill-in with values.
-	 * @param  iterable  values used to fill the form
-	 * @param  bool     erase other controls?
+	 * @param  iterable
+	 * @param  bool
 	 * @return static
 	 * @internal
 	 */
@@ -88,7 +88,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Returns the values submitted by the form.
-	 * @param  bool  return values as an array?
+	 * @param  bool
 	 * @return Nette\Utils\ArrayHash|array
 	 */
 	public function getValues($asArray = FALSE)
@@ -180,7 +180,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Returns current group.
-	 * @return ControlGroup
+	 * @return ControlGroup|NULL
 	 */
 	public function getCurrentGroup()
 	{
@@ -191,7 +191,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	/**
 	 * Adds the specified component to the IContainer.
 	 * @param  Nette\ComponentModel\IComponent
-	 * @param  string
+	 * @param  string|int
 	 * @param  string
 	 * @return static
 	 * @throws Nette\InvalidStateException
@@ -208,7 +208,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Iterates over all form controls.
-	 * @return \ArrayIterator
+	 * @return \Iterator
 	 */
 	public function getControls()
 	{
@@ -219,7 +219,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	/**
 	 * Returns form.
 	 * @param  bool
-	 * @return Form
+	 * @return Form|NULL
 	 */
 	public function getForm($throw = TRUE)
 	{
@@ -232,10 +232,10 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds single-line text input control to the form.
-	 * @param  string  control name
-	 * @param  string  label
-	 * @param  int  width of the control (deprecated)
-	 * @param  int  maximum number of characters the user may enter
+	 * @param  string
+	 * @param  string|object
+	 * @param  int
+	 * @param  int
 	 * @return Controls\TextInput
 	 */
 	public function addText($name, $label = NULL, $cols = NULL, $maxLength = NULL)
@@ -247,10 +247,10 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds single-line text input control used for sensitive input such as passwords.
-	 * @param  string  control name
-	 * @param  string  label
-	 * @param  int  width of the control (deprecated)
-	 * @param  int  maximum number of characters the user may enter
+	 * @param  string
+	 * @param  string|object
+	 * @param  int
+	 * @param  int
 	 * @return Controls\TextInput
 	 */
 	public function addPassword($name, $label = NULL, $cols = NULL, $maxLength = NULL)
@@ -263,10 +263,10 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds multi-line text input control to the form.
-	 * @param  string  control name
-	 * @param  string  label
-	 * @param  int  width of the control
-	 * @param  int  height of the control in text lines
+	 * @param  string
+	 * @param  string|object
+	 * @param  int
+	 * @param  int
 	 * @return Controls\TextArea
 	 */
 	public function addTextArea($name, $label = NULL, $cols = NULL, $rows = NULL)
@@ -278,8 +278,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds input for email.
-	 * @param  string  control name
-	 * @param  string  label
+	 * @param  string
+	 * @param  string|object
 	 * @return Controls\TextInput
 	 */
 	public function addEmail($name, $label = NULL)
@@ -292,8 +292,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds input for integer.
-	 * @param  string  control name
-	 * @param  string  label
+	 * @param  string
+	 * @param  string|object
 	 * @return Controls\TextInput
 	 */
 	public function addInteger($name, $label = NULL)
@@ -307,9 +307,9 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds control that allows the user to upload files.
-	 * @param  string  control name
-	 * @param  string  label
-	 * @param  bool  allows to upload multiple files
+	 * @param  string
+	 * @param  string|object
+	 * @param  bool
 	 * @return Controls\UploadControl
 	 */
 	public function addUpload($name, $label = NULL, $multiple = FALSE)
@@ -320,8 +320,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds control that allows the user to upload multiple files.
-	 * @param  string  control name
-	 * @param  string  label
+	 * @param  string
+	 * @param  string|object
 	 * @return Controls\UploadControl
 	 */
 	public function addMultiUpload($name, $label = NULL)
@@ -332,8 +332,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds hidden form control used to store a non-displayed value.
-	 * @param  string  control name
-	 * @param  mixed   default value
+	 * @param  string
+	 * @param  string
 	 * @return Controls\HiddenField
 	 */
 	public function addHidden($name, $default = NULL)
@@ -345,8 +345,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds check box control to the form.
-	 * @param  string  control name
-	 * @param  string  caption
+	 * @param  string
+	 * @param  string|object
 	 * @return Controls\Checkbox
 	 */
 	public function addCheckbox($name, $caption = NULL)
@@ -357,9 +357,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds set of radio button controls to the form.
-	 * @param  string  control name
-	 * @param  string  label
-	 * @param  array   options from which to choose
+	 * @param  string
+	 * @param  string|object
 	 * @return Controls\RadioList
 	 */
 	public function addRadioList($name, $label = NULL, array $items = NULL)
@@ -370,6 +369,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds set of checkbox controls to the form.
+	 * @param  string
+	 * @param  string|object
 	 * @return Controls\CheckboxList
 	 */
 	public function addCheckboxList($name, $label = NULL, array $items = NULL)
@@ -380,10 +381,10 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds select box control that allows single item selection.
-	 * @param  string  control name
-	 * @param  string  label
-	 * @param  array   items from which to choose
-	 * @param  int     number of rows that should be visible
+	 * @param  string
+	 * @param  string|object
+	 * @param  array
+	 * @param  int
 	 * @return Controls\SelectBox
 	 */
 	public function addSelect($name, $label = NULL, array $items = NULL, $size = NULL)
@@ -395,10 +396,10 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds select box control that allows multiple item selection.
-	 * @param  string  control name
-	 * @param  string  label
-	 * @param  array   options from which to choose
-	 * @param  int     number of rows that should be visible
+	 * @param  string
+	 * @param  string|object
+	 * @param  array
+	 * @param  int
 	 * @return Controls\MultiSelectBox
 	 */
 	public function addMultiSelect($name, $label = NULL, array $items = NULL, $size = NULL)
@@ -410,8 +411,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds button used to submit form.
-	 * @param  string  control name
-	 * @param  string  caption
+	 * @param  string
+	 * @param  string|object
 	 * @return Controls\SubmitButton
 	 */
 	public function addSubmit($name, $caption = NULL)
@@ -422,8 +423,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds push buttons with no default behavior.
-	 * @param  string  control name
-	 * @param  string  caption
+	 * @param  string
+	 * @param  string|object
 	 * @return Controls\Button
 	 */
 	public function addButton($name, $caption = NULL)
@@ -434,7 +435,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds graphical button used to submit form.
-	 * @param  string  control name
+	 * @param  string
 	 * @param  string  URI of the image
 	 * @param  string  alternate text for the image
 	 * @return Controls\ImageButton
@@ -447,7 +448,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds naming container to the form.
-	 * @param  string  name
+	 * @param  string|int
 	 * @return self
 	 */
 	public function addContainer($name)
@@ -487,7 +488,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Adds the component to the container.
-	 * @param  string  component name
+	 * @param  string|int
 	 * @param  Nette\ComponentModel\IComponent
 	 * @return void
 	 */
@@ -499,7 +500,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Returns component specified by name. Throws exception if component doesn't exist.
-	 * @param  string  component name
+	 * @param  string|int
 	 * @return Nette\ComponentModel\IComponent
 	 * @throws Nette\InvalidArgumentException
 	 */
@@ -511,7 +512,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Does component specified by name exists?
-	 * @param  string  component name
+	 * @param  string|int
 	 * @return bool
 	 */
 	public function offsetExists($name)
@@ -522,7 +523,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Removes component from the container.
-	 * @param  string  component name
+	 * @param  string|int
 	 * @return void
 	 */
 	public function offsetUnset($name)

--- a/src/Forms/ControlGroup.php
+++ b/src/Forms/ControlGroup.php
@@ -73,8 +73,8 @@ class ControlGroup
 	 * - 'description' - textual or IHtmlString object description
 	 * - 'embedNext' - describes how render next group
 	 *
-	 * @param  string key
-	 * @param  mixed  value
+	 * @param  string
+	 * @param  mixed
 	 * @return static
 	 */
 	public function setOption($key, $value)
@@ -91,8 +91,8 @@ class ControlGroup
 
 	/**
 	 * Returns user-specific option.
-	 * @param  string key
-	 * @param  mixed  default value
+	 * @param  string
+	 * @param  mixed
 	 * @return mixed
 	 */
 	public function getOption($key, $default = NULL)

--- a/src/Forms/Controls/BaseControl.php
+++ b/src/Forms/Controls/BaseControl.php
@@ -19,7 +19,7 @@ use Nette\Utils\Html;
  *
  * @property-read Form $form
  * @property-read string $htmlName
- * @property   string $htmlId
+ * @property   mixed $htmlId
  * @property   mixed $value
  * @property   bool $disabled
  * @property   bool $omitted
@@ -38,7 +38,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	/** @var string */
 	public static $idMask = 'frm-%s';
 
-	/** @var string textual caption or label */
+	/** @var string|object textual caption or label */
 	public $caption;
 
 	/** @var mixed current control value */
@@ -73,7 +73,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 
 	/**
-	 * @param  string  caption
+	 * @param  string|object
 	 */
 	public function __construct($caption = NULL)
 	{
@@ -106,7 +106,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	/**
 	 * Returns form.
 	 * @param  bool
-	 * @return Form
+	 * @return Form|NULL
 	 */
 	public function getForm($throw = TRUE)
 	{
@@ -265,7 +265,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Generates label's HTML element.
-	 * @param  string
+	 * @param  string|object
 	 * @return Html|string
 	 */
 	public function getLabel($caption = NULL)
@@ -317,7 +317,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Changes control's HTML id.
-	 * @param  string new ID, or FALSE or NULL
+	 * @param  mixed  new ID, or FALSE or NULL
 	 * @return static
 	 */
 	public function setHtmlId($id)
@@ -329,7 +329,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Returns control's HTML id.
-	 * @return string
+	 * @return mixed
 	 */
 	public function getHtmlId()
 	{
@@ -342,8 +342,8 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Changes control's HTML attribute.
-	 * @param  string name
-	 * @param  mixed  value
+	 * @param  string
+	 * @param  mixed
 	 * @return static
 	 */
 	public function setHtmlAttribute($name, $value = TRUE)
@@ -354,8 +354,8 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Alias for setHtmlAttribute()
-	 * @param  string name
-	 * @param  mixed  value
+	 * @param  string
+	 * @param  mixed
 	 * @return static
 	 */
 	public function setAttribute($name, $value = TRUE)
@@ -396,7 +396,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	 * Returns translated string.
 	 * @param  mixed
 	 * @param  int      plural count
-	 * @return string
+	 * @return mixed
 	 */
 	public function translate($value, $count = NULL)
 	{
@@ -417,9 +417,9 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Adds a validation rule.
-	 * @param  mixed      rule type
-	 * @param  string     message to display for invalid data
-	 * @param  mixed      optional rule arguments
+	 * @param  mixed
+	 * @param  string|object
+	 * @param  mixed
 	 * @return static
 	 */
 	public function addRule($validator, $errorMessage = NULL, $arg = NULL)
@@ -431,8 +431,8 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Adds a validation condition a returns new branch.
-	 * @param  mixed     condition type
-	 * @param  mixed     optional condition arguments
+	 * @param  mixed
+	 * @param  mixed
 	 * @return Rules      new branch
 	 */
 	public function addCondition($validator, $value = NULL)
@@ -443,9 +443,9 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Adds a validation condition based on another control a returns new branch.
-	 * @param  IControl form control
-	 * @param  mixed      condition type
-	 * @param  mixed      optional condition arguments
+	 * @param  IControl
+	 * @param  mixed
+	 * @param  mixed
 	 * @return Rules      new branch
 	 */
 	public function addConditionOn(IControl $control, $validator, $value = NULL)
@@ -501,7 +501,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Adds error message to the list.
-	 * @param  string  error message
+	 * @param  string|object
 	 * @return void
 	 */
 	public function addError($message)
@@ -512,7 +512,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Returns errors corresponding to control.
-	 * @return string
+	 * @return string|NULL
 	 */
 	public function getError()
 	{

--- a/src/Forms/Controls/BaseControl.php
+++ b/src/Forms/Controls/BaseControl.php
@@ -105,12 +105,12 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 
 	/**
 	 * Returns form.
-	 * @param  bool   throw exception if form doesn't exist?
+	 * @param  bool
 	 * @return Form
 	 */
-	public function getForm($need = TRUE)
+	public function getForm($throw = TRUE)
 	{
-		return $this->lookup(Form::class, $need);
+		return $this->lookup(Form::class, $throw);
 	}
 
 
@@ -422,9 +422,9 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	 * @param  mixed      optional rule arguments
 	 * @return static
 	 */
-	public function addRule($validator, $message = NULL, $arg = NULL)
+	public function addRule($validator, $errorMessage = NULL, $arg = NULL)
 	{
-		$this->rules->addRule($validator, $message, $arg);
+		$this->rules->addRule($validator, $errorMessage, $arg);
 		return $this;
 	}
 

--- a/src/Forms/Controls/Button.php
+++ b/src/Forms/Controls/Button.php
@@ -17,7 +17,7 @@ class Button extends BaseControl
 {
 
 	/**
-	 * @param  string  caption
+	 * @param  string|object
 	 */
 	public function __construct($caption = NULL)
 	{
@@ -44,13 +44,12 @@ class Button extends BaseControl
 	 */
 	public function getLabel($caption = NULL)
 	{
-		return NULL;
 	}
 
 
 	/**
 	 * Generates control's HTML element.
-	 * @param  string
+	 * @param  string|object
 	 * @return Nette\Utils\Html
 	 */
 	public function getControl($caption = NULL)

--- a/src/Forms/Controls/Checkbox.php
+++ b/src/Forms/Controls/Checkbox.php
@@ -20,7 +20,7 @@ class Checkbox extends BaseControl
 
 
 	/**
-	 * @param  string  label
+	 * @param  string|object
 	 */
 	public function __construct($label = NULL)
 	{
@@ -73,7 +73,6 @@ class Checkbox extends BaseControl
 	 */
 	public function getLabel($caption = NULL)
 	{
-		return NULL;
 	}
 
 

--- a/src/Forms/Controls/Checkbox.php
+++ b/src/Forms/Controls/Checkbox.php
@@ -8,6 +8,7 @@
 namespace Nette\Forms\Controls;
 
 use Nette;
+use Nette\Utils\Html;
 
 
 /**
@@ -15,7 +16,7 @@ use Nette;
  */
 class Checkbox extends BaseControl
 {
-	/** @var Nette\Utils\Html  wrapper element template */
+	/** @var Html  wrapper element template */
 	private $wrapper;
 
 
@@ -26,7 +27,7 @@ class Checkbox extends BaseControl
 	{
 		parent::__construct($label);
 		$this->control->type = 'checkbox';
-		$this->wrapper = Nette\Utils\Html::el();
+		$this->wrapper = Html::el();
 		$this->setOption('type', 'checkbox');
 	}
 
@@ -59,7 +60,7 @@ class Checkbox extends BaseControl
 
 	/**
 	 * Generates control's HTML element.
-	 * @return Nette\Utils\Html
+	 * @return Html
 	 */
 	public function getControl()
 	{
@@ -77,7 +78,7 @@ class Checkbox extends BaseControl
 
 
 	/**
-	 * @return Nette\Utils\Html
+	 * @return Html
 	 */
 	public function getControlPart()
 	{
@@ -86,7 +87,7 @@ class Checkbox extends BaseControl
 
 
 	/**
-	 * @return Nette\Utils\Html
+	 * @return Html
 	 */
 	public function getLabelPart()
 	{
@@ -96,7 +97,7 @@ class Checkbox extends BaseControl
 
 	/**
 	 * Returns wrapper HTML element template.
-	 * @return Nette\Utils\Html
+	 * @return Html
 	 */
 	public function getSeparatorPrototype()
 	{

--- a/src/Forms/Controls/CheckboxList.php
+++ b/src/Forms/Controls/CheckboxList.php
@@ -31,8 +31,7 @@ class CheckboxList extends MultiChoiceControl
 
 
 	/**
-	 * @param  string  label
-	 * @param  array   options from which to choose
+	 * @param  string|object
 	 */
 	public function __construct($label = NULL, array $items = NULL)
 	{
@@ -74,7 +73,7 @@ class CheckboxList extends MultiChoiceControl
 
 	/**
 	 * Generates label's HTML element.
-	 * @param  string
+	 * @param  string|object
 	 * @return Html
 	 */
 	public function getLabel($caption = NULL)

--- a/src/Forms/Controls/CsrfProtection.php
+++ b/src/Forms/Controls/CsrfProtection.php
@@ -105,7 +105,7 @@ class CsrfProtection extends HiddenField
 	 */
 	public static function validateCsrf(CsrfProtection $control)
 	{
-		$value = $control->getValue();
+		$value = (string) $control->getValue();
 		return $control->generateToken(substr($value, 0, 10)) === $value;
 	}
 

--- a/src/Forms/Controls/CsrfProtection.php
+++ b/src/Forms/Controls/CsrfProtection.php
@@ -25,12 +25,12 @@ class CsrfProtection extends HiddenField
 	 * @param string
 	 * @param int
 	 */
-	public function __construct($message)
+	public function __construct($errorMessage)
 	{
 		parent::__construct();
 		$this->setOmitted()
 			->setRequired()
-			->addRule(self::PROTECTION, $message);
+			->addRule(self::PROTECTION, $errorMessage);
 		$this->monitor(Nette\Application\UI\Presenter::class);
 	}
 

--- a/src/Forms/Controls/CsrfProtection.php
+++ b/src/Forms/Controls/CsrfProtection.php
@@ -22,8 +22,7 @@ class CsrfProtection extends HiddenField
 
 
 	/**
-	 * @param string
-	 * @param int
+	 * @param string|object
 	 */
 	public function __construct($errorMessage)
 	{

--- a/src/Forms/Controls/HiddenField.php
+++ b/src/Forms/Controls/HiddenField.php
@@ -68,17 +68,17 @@ class HiddenField extends BaseControl
 
 	/**
 	 * Bypasses label generation.
+	 * @param  string|object
 	 * @return void
 	 */
 	public function getLabel($caption = NULL)
 	{
-		return NULL;
 	}
 
 
 	/**
 	 * Adds error message to the list.
-	 * @param  string  error message
+	 * @param  string|object
 	 * @return void
 	 */
 	public function addError($message)

--- a/src/Forms/Controls/MultiSelectBox.php
+++ b/src/Forms/Controls/MultiSelectBox.php
@@ -18,6 +18,9 @@ class MultiSelectBox extends MultiChoiceControl
 	/** @var array of option / optgroup */
 	private $options = [];
 
+	/** @var bool */
+	private $translateOptions = TRUE;
+
 	/** @var array */
 	private $optionAttributes = [];
 
@@ -26,6 +29,18 @@ class MultiSelectBox extends MultiChoiceControl
 	{
 		parent::__construct($label, $items);
 		$this->setOption('type', 'select');
+	}
+
+
+	/**
+	 * Disable translation of select options.
+	 * @param  bool
+	 * @return static
+	 */
+	public function setTranslateOptions($translateOptions = TRUE)
+	{
+		$this->translateOptions = (bool) $translateOptions;
+		return $this;
 	}
 
 
@@ -62,7 +77,11 @@ class MultiSelectBox extends MultiChoiceControl
 	{
 		$items = [];
 		foreach ($this->options as $key => $value) {
-			$items[is_array($value) ? $this->translate($key) : $key] = $this->translate($value);
+			if (is_array($value) && $this->translateOptions) {
+				$key = $this->translate($key);
+			}
+
+			$items[$key] = $this->translateOptions ? $this->translate($value) : $value;
 		}
 
 		return Nette\Forms\Helpers::createSelectBox(

--- a/src/Forms/Controls/RadioList.php
+++ b/src/Forms/Controls/RadioList.php
@@ -34,8 +34,7 @@ class RadioList extends ChoiceControl
 
 
 	/**
-	 * @param  string  label
-	 * @param  array   options from which to choose
+	 * @param  string|object
 	 */
 	public function __construct($label = NULL, array $items = NULL)
 	{
@@ -81,7 +80,7 @@ class RadioList extends ChoiceControl
 
 	/**
 	 * Generates label's HTML element.
-	 * @param  string
+	 * @param  string|object
 	 * @return Html
 	 */
 	public function getLabel($caption = NULL)

--- a/src/Forms/Controls/SelectBox.php
+++ b/src/Forms/Controls/SelectBox.php
@@ -39,7 +39,7 @@ class SelectBox extends ChoiceControl
 
 	/**
 	 * Sets first prompt item in select box.
-	 * @param  string
+	 * @param  string|object
 	 * @return static
 	 */
 	public function setPrompt($prompt)

--- a/src/Forms/Controls/SelectBox.php
+++ b/src/Forms/Controls/SelectBox.php
@@ -21,6 +21,9 @@ class SelectBox extends ChoiceControl
 	/** @var array of option / optgroup */
 	private $options = [];
 
+	/** @var bool */
+	private $translateOptions = TRUE;
+
 	/** @var mixed */
 	private $prompt = FALSE;
 
@@ -34,6 +37,18 @@ class SelectBox extends ChoiceControl
 		$this->setOption('type', 'select');
 		$this->addCondition(Nette\Forms\Form::BLANK)
 			->addRule([$this, 'isOk'], Nette\Forms\Validator::$messages[self::VALID]);
+	}
+
+
+	/**
+	 * Disable translation of select options.
+	 * @param  bool
+	 * @return static
+	 */
+	public function setTranslateOptions($translateOptions = TRUE)
+	{
+		$this->translateOptions = (bool) $translateOptions;
+		return $this;
 	}
 
 
@@ -92,7 +107,11 @@ class SelectBox extends ChoiceControl
 	{
 		$items = $this->prompt === FALSE ? [] : ['' => $this->translate($this->prompt)];
 		foreach ($this->options as $key => $value) {
-			$items[is_array($value) ? $this->translate($key) : $key] = $this->translate($value);
+			if (is_array($value) && $this->translateOptions) {
+				$key = $this->translate($key);
+			}
+
+			$items[$key] = $this->translateOptions ? $this->translate($value) : $value;
 		}
 
 		return Nette\Forms\Helpers::createSelectBox(

--- a/src/Forms/Controls/SubmitButton.php
+++ b/src/Forms/Controls/SubmitButton.php
@@ -23,12 +23,12 @@ class SubmitButton extends Button implements Nette\Forms\ISubmitterControl
 	/** @var callable[]  function (SubmitButton $sender); Occurs when the button is clicked and form is not validated */
 	public $onInvalidClick;
 
-	/** @var array */
+	/** @var array|NULL */
 	private $validationScope;
 
 
 	/**
-	 * @param  string  caption
+	 * @param  string|object
 	 */
 	public function __construct($caption = NULL)
 	{
@@ -104,7 +104,7 @@ class SubmitButton extends Button implements Nette\Forms\ISubmitterControl
 
 	/**
 	 * Generates control's HTML element.
-	 * @param  string
+	 * @param  string|object
 	 * @return Nette\Utils\Html
 	 */
 	public function getControl($caption = NULL)

--- a/src/Forms/Controls/TextArea.php
+++ b/src/Forms/Controls/TextArea.php
@@ -17,7 +17,7 @@ class TextArea extends TextBase
 {
 
 	/**
-	 * @param  string  label
+	 * @param  string|object
 	 */
 	public function __construct($label = NULL)
 	{

--- a/src/Forms/Controls/TextBase.php
+++ b/src/Forms/Controls/TextBase.php
@@ -29,7 +29,6 @@ abstract class TextBase extends BaseControl
 
 	/**
 	 * Sets control's value.
-	 * @param  string
 	 * @return static
 	 * @internal
 	 */
@@ -48,7 +47,7 @@ abstract class TextBase extends BaseControl
 
 	/**
 	 * Returns control's value.
-	 * @return string
+	 * @return mixed
 	 */
 	public function getValue()
 	{
@@ -138,6 +137,9 @@ abstract class TextBase extends BaseControl
 	}
 
 
+	/**
+	 * @return static
+	 */
 	public function addRule($validator, $errorMessage = NULL, $arg = NULL)
 	{
 		if ($validator === Form::LENGTH || $validator === Form::MAX_LENGTH) {

--- a/src/Forms/Controls/TextBase.php
+++ b/src/Forms/Controls/TextBase.php
@@ -40,7 +40,8 @@ abstract class TextBase extends BaseControl
 		} elseif (!is_scalar($value) && !method_exists($value, '__toString')) {
 			throw new Nette\InvalidArgumentException(sprintf("Value must be scalar or NULL, %s given in field '%s'.", gettype($value), $this->name));
 		}
-		$this->rawValue = $this->value = $value;
+		$this->value = $value;
+		$this->rawValue = (string) $value;
 		return $this;
 	}
 

--- a/src/Forms/Controls/TextBase.php
+++ b/src/Forms/Controls/TextBase.php
@@ -138,7 +138,7 @@ abstract class TextBase extends BaseControl
 	}
 
 
-	public function addRule($validator, $message = NULL, $arg = NULL)
+	public function addRule($validator, $errorMessage = NULL, $arg = NULL)
 	{
 		if ($validator === Form::LENGTH || $validator === Form::MAX_LENGTH) {
 			$tmp = is_array($arg) ? $arg[1] : $arg;
@@ -146,7 +146,7 @@ abstract class TextBase extends BaseControl
 				$this->control->maxlength = isset($this->control->maxlength) ? min($this->control->maxlength, $tmp) : $tmp;
 			}
 		}
-		return parent::addRule($validator, $message, $arg);
+		return parent::addRule($validator, $errorMessage, $arg);
 	}
 
 

--- a/src/Forms/Controls/TextInput.php
+++ b/src/Forms/Controls/TextInput.php
@@ -18,8 +18,8 @@ class TextInput extends TextBase
 {
 
 	/**
-	 * @param  string  label
-	 * @param  int  maximum number of characters the user may enter
+	 * @param  string|object
+	 * @param  int
 	 */
 	public function __construct($label = NULL, $maxLength = NULL)
 	{
@@ -75,6 +75,9 @@ class TextInput extends TextBase
 	}
 
 
+	/**
+	 * @return static
+	 */
 	public function addRule($validator, $errorMessage = NULL, $arg = NULL)
 	{
 		if ($this->control->type === NULL && in_array($validator, [Form::EMAIL, Form::URL, Form::INTEGER], TRUE)) {

--- a/src/Forms/Controls/TextInput.php
+++ b/src/Forms/Controls/TextInput.php
@@ -75,7 +75,7 @@ class TextInput extends TextBase
 	}
 
 
-	public function addRule($validator, $message = NULL, $arg = NULL)
+	public function addRule($validator, $errorMessage = NULL, $arg = NULL)
 	{
 		if ($this->control->type === NULL && in_array($validator, [Form::EMAIL, Form::URL, Form::INTEGER], TRUE)) {
 			static $types = [Form::EMAIL => 'email', Form::URL => 'url', Form::INTEGER => 'number'];
@@ -104,7 +104,7 @@ class TextInput extends TextBase
 			$this->control->pattern = $arg;
 		}
 
-		return parent::addRule($validator, $message, $arg);
+		return parent::addRule($validator, $errorMessage, $arg);
 	}
 
 }

--- a/src/Forms/Controls/UploadControl.php
+++ b/src/Forms/Controls/UploadControl.php
@@ -21,8 +21,8 @@ class UploadControl extends BaseControl
 	const VALID = ':uploadControlValid';
 
 	/**
-	 * @param  string  label
-	 * @param  bool  allows to upload multiple files
+	 * @param  string|object
+	 * @param  bool
 	 */
 	public function __construct($label = NULL, $multiple = FALSE)
 	{

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -162,7 +162,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 	 * Returns self.
 	 * @return static
 	 */
-	public function getForm($need = TRUE)
+	public function getForm($throw = TRUE)
 	{
 		return $this;
 	}
@@ -231,9 +231,9 @@ class Form extends Container implements Nette\Utils\IHtmlString
 	 * @param  string
 	 * @return Controls\CsrfProtection
 	 */
-	public function addProtection($message = NULL)
+	public function addProtection($errorMessage = NULL)
 	{
-		$control = new Controls\CsrfProtection($message);
+		$control = new Controls\CsrfProtection($errorMessage);
 		$this->addComponent($control, self::PROTECTOR_ID, key($this->getComponents()));
 		return $control;
 	}

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -8,6 +8,7 @@
 namespace Nette\Forms;
 
 use Nette;
+use Nette\Utils\Html;
 
 
 /**
@@ -15,7 +16,7 @@ use Nette;
  *
  * @property-read array $errors
  * @property-read array $ownErrors
- * @property-read Nette\Utils\Html $elementPrototype
+ * @property-read Html $elementPrototype
  * @property-read IFormRenderer $renderer
  * @property string $action
  * @property string $method
@@ -95,7 +96,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 	/** @var array */
 	private $httpData;
 
-	/** @var Nette\Utils\Html  <form> element */
+	/** @var Html  <form> element */
 	private $element;
 
 	/** @var IFormRenderer */
@@ -566,12 +567,12 @@ class Form extends Container implements Nette\Utils\IHtmlString
 
 	/**
 	 * Returns form's HTML element template.
-	 * @return Nette\Utils\Html
+	 * @return Html
 	 */
 	public function getElementPrototype()
 	{
 		if (!$this->element) {
-			$this->element = Nette\Utils\Html::el('form');
+			$this->element = Html::el('form');
 			$this->element->action = ''; // RFC 1808 -> empty uri means 'this'
 			$this->element->method = self::POST;
 		}

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -170,7 +170,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 
 	/**
 	 * Sets form's action.
-	 * @param  mixed URI
+	 * @param  string|object
 	 * @return static
 	 */
 	public function setAction($url)
@@ -182,7 +182,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 
 	/**
 	 * Returns form's action.
-	 * @return mixed URI
+	 * @return mixed
 	 */
 	public function getAction()
 	{
@@ -191,8 +191,8 @@ class Form extends Container implements Nette\Utils\IHtmlString
 
 
 	/**
-	 * Sets form's method.
-	 * @param  string get | post
+	 * Sets form's method GET or POST.
+	 * @param  string
 	 * @return static
 	 */
 	public function setMethod($method)
@@ -207,7 +207,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 
 	/**
 	 * Returns form's method.
-	 * @return string get | post
+	 * @return string
 	 */
 	public function getMethod()
 	{
@@ -241,8 +241,8 @@ class Form extends Container implements Nette\Utils\IHtmlString
 
 	/**
 	 * Adds fieldset group to the form.
-	 * @param  string  caption
-	 * @param  bool    set this group as current
+	 * @param  string
+	 * @param  bool
 	 * @return ControlGroup
 	 */
 	public function addGroup($caption = NULL, $setAsCurrent = TRUE)
@@ -265,7 +265,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 
 	/**
 	 * Removes fieldset group from form.
-	 * @param  string|ControlGroup
+	 * @param  string|int|ControlGroup
 	 * @return void
 	 */
 	public function removeGroup($name)
@@ -301,8 +301,8 @@ class Form extends Container implements Nette\Utils\IHtmlString
 
 	/**
 	 * Returns the specified group.
-	 * @param  string  name
-	 * @return ControlGroup
+	 * @param  string|int
+	 * @return ControlGroup|NULL
 	 */
 	public function getGroup($name)
 	{
@@ -384,6 +384,8 @@ class Form extends Container implements Nette\Utils\IHtmlString
 
 	/**
 	 * Returns submitted HTTP data.
+	 * @param  int
+	 * @param  string
 	 * @return mixed
 	 */
 	public function getHttpData($type = NULL, $htmlName = NULL)
@@ -479,6 +481,9 @@ class Form extends Container implements Nette\Utils\IHtmlString
 	/********************* validation ****************d*g**/
 
 
+	/**
+	 * @return void
+	 */
 	public function validate(array $controls = NULL)
 	{
 		$this->cleanErrors();
@@ -509,7 +514,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 
 	/**
 	 * Adds global error message.
-	 * @param  string  error message
+	 * @param  string|object
 	 * @return void
 	 */
 	public function addError($message)

--- a/src/Forms/Helpers.php
+++ b/src/Forms/Helpers.php
@@ -27,9 +27,9 @@ class Helpers
 
 	/**
 	 * Extracts and sanitizes submitted form data for single control.
-	 * @param  array   submitted data
-	 * @param  string  control HTML name
-	 * @param  string  type Form::DATA_TEXT, DATA_LINE, DATA_FILE, DATA_KEYS
+	 * @param  array
+	 * @param  string
+	 * @param  int  type Form::DATA_TEXT, DATA_LINE, DATA_FILE, DATA_KEYS
 	 * @return string|string[]
 	 * @internal
 	 */

--- a/src/Forms/Helpers.php
+++ b/src/Forms/Helpers.php
@@ -65,7 +65,7 @@ class Helpers
 			return is_scalar($value) ? Strings::normalizeNewLines($value) : NULL;
 
 		} elseif ($type === Form::DATA_LINE) {
-			return is_scalar($value) ? Strings::trim(strtr($value, "\r\n", '  ')) : NULL;
+			return is_scalar($value) ? Strings::trim(strtr((string) $value, "\r\n", '  ')) : NULL;
 
 		} elseif ($type === Form::DATA_FILE) {
 			return $value instanceof Nette\Http\FileUpload ? $value : NULL;
@@ -198,7 +198,7 @@ class Helpers
 					$res .= $caption->setName('option')->addAttributes($option->attrs);
 				} else {
 					$res .= $optionTag . $option->attributes() . '>'
-						. htmlspecialchars($caption, ENT_NOQUOTES, 'UTF-8')
+						. htmlspecialchars((string) $caption, ENT_NOQUOTES, 'UTF-8')
 						. '</option>';
 				}
 			}

--- a/src/Forms/IControl.php
+++ b/src/Forms/IControl.php
@@ -17,7 +17,7 @@ interface IControl
 	/**
 	 * Sets control's value.
 	 * @param  mixed
-	 * @return void
+	 * @return static
 	 */
 	function setValue($value);
 

--- a/src/Forms/ISubmitterControl.php
+++ b/src/Forms/ISubmitterControl.php
@@ -16,7 +16,7 @@ interface ISubmitterControl extends IControl
 
 	/**
 	 * Gets the validation scope. Clicking the button validates only the controls within the specified scope.
-	 * @return mixed
+	 * @return array|NULL
 	 */
 	function getValidationScope();
 

--- a/src/Forms/Rendering/DefaultFormRenderer.php
+++ b/src/Forms/Rendering/DefaultFormRenderer.php
@@ -171,7 +171,7 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 			$query = parse_url($el->action, PHP_URL_QUERY);
 			$el->action = str_replace("?$query", '', $el->action);
 			$s = '';
-			foreach (preg_split('#[;&]#', $query, NULL, PREG_SPLIT_NO_EMPTY) as $param) {
+			foreach (preg_split('#[;&]#', $query, -1, PREG_SPLIT_NO_EMPTY) as $param) {
 				$parts = explode('=', $param, 2);
 				$name = urldecode($parts[0]);
 				if (!isset($this->form[$name])) {

--- a/src/Forms/Rendering/DefaultFormRenderer.php
+++ b/src/Forms/Rendering/DefaultFormRenderer.php
@@ -219,7 +219,7 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 			? $control->getErrors()
 			: ($own ? $this->form->getOwnErrors() : $this->form->getErrors());
 		if (!$errors) {
-			return;
+			return '';
 		}
 		$container = $this->getWrapper($control ? 'control errorcontainer' : 'error container');
 		$item = $this->getWrapper($control ? 'control erroritem' : 'error item');
@@ -407,7 +407,7 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 
 	/**
 	 * Renders 'label' part of visual row of controls.
-	 * @return string
+	 * @return Html
 	 */
 	public function renderLabel(Nette\Forms\IControl $control)
 	{
@@ -427,7 +427,7 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 
 	/**
 	 * Renders 'control' part of visual row of controls.
-	 * @return string
+	 * @return Html
 	 */
 	public function renderControl(Nette\Forms\IControl $control)
 	{
@@ -476,7 +476,7 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 
 	/**
 	 * @param  string
-	 * @return string
+	 * @return mixed
 	 */
 	protected function getValue($name)
 	{

--- a/src/Forms/Rules.php
+++ b/src/Forms/Rules.php
@@ -79,9 +79,9 @@ class Rules implements \IteratorAggregate
 
 	/**
 	 * Adds a validation rule for the current control.
-	 * @param  mixed      rule type
-	 * @param  string     message to display for invalid data
-	 * @param  mixed      optional rule arguments
+	 * @param  mixed
+	 * @param  string|object
+	 * @param  mixed
 	 * @return static
 	 */
 	public function addRule($validator, $errorMessage = NULL, $arg = NULL)
@@ -106,8 +106,8 @@ class Rules implements \IteratorAggregate
 
 	/**
 	 * Adds a validation condition and returns new branch.
-	 * @param  mixed      condition type
-	 * @param  mixed      optional condition arguments
+	 * @param  mixed
+	 * @param  mixed
 	 * @return static       new branch
 	 */
 	public function addCondition($validator, $arg = NULL)
@@ -121,9 +121,9 @@ class Rules implements \IteratorAggregate
 
 	/**
 	 * Adds a validation condition on specified control a returns new branch.
-	 * @param  IControl form control
-	 * @param  mixed      condition type
-	 * @param  mixed      optional condition arguments
+	 * @param  IControl
+	 * @param  mixed
+	 * @param  mixed
 	 * @return static     new branch
 	 */
 	public function addConditionOn(IControl $control, $validator, $arg = NULL)
@@ -186,8 +186,8 @@ class Rules implements \IteratorAggregate
 
 	/**
 	 * Toggles HTML element visibility.
-	 * @param  string     element id
-	 * @param  bool       hide element?
+	 * @param  string
+	 * @param  bool
 	 * @return static
 	 */
 	public function toggle($id, $hide = TRUE)
@@ -291,7 +291,7 @@ class Rules implements \IteratorAggregate
 
 	/**
 	 * Iterates over complete ruleset.
-	 * @return \ArrayIterator
+	 * @return \Iterator
 	 */
 	public function getIterator()
 	{
@@ -305,10 +305,9 @@ class Rules implements \IteratorAggregate
 
 	/**
 	 * Process 'operation' string.
-	 * @param  Rule
 	 * @return void
 	 */
-	private function adjustOperation($rule)
+	private function adjustOperation(Rule $rule)
 	{
 		if (is_string($rule->validator) && ord($rule->validator[0]) > 127) {
 			$rule->isNegative = TRUE;
@@ -331,7 +330,7 @@ class Rules implements \IteratorAggregate
 	}
 
 
-	private static function getCallback($rule)
+	private static function getCallback(Rule $rule)
 	{
 		$op = $rule->validator;
 		if (is_string($op) && strncmp($op, ':', 1) === 0) {

--- a/src/Forms/Rules.php
+++ b/src/Forms/Rules.php
@@ -84,7 +84,7 @@ class Rules implements \IteratorAggregate
 	 * @param  mixed      optional rule arguments
 	 * @return static
 	 */
-	public function addRule($validator, $message = NULL, $arg = NULL)
+	public function addRule($validator, $errorMessage = NULL, $arg = NULL)
 	{
 		if ($validator === Form::VALID || $validator === ~Form::VALID) {
 			throw new Nette\InvalidArgumentException('You cannot use Form::VALID in the addRule method.');
@@ -94,7 +94,7 @@ class Rules implements \IteratorAggregate
 		$rule->validator = $validator;
 		$this->adjustOperation($rule);
 		$rule->arg = $arg;
-		$rule->message = $message;
+		$rule->message = $errorMessage;
 		if ($rule->validator === Form::REQUIRED) {
 			$this->required = $rule;
 		} else {

--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -143,6 +143,8 @@ class Validator
 
 	/**
 	 * Is a control's value number in specified range?
+	 * @param  IControl
+	 * @param  array
 	 * @return bool
 	 */
 	public static function validateRange(IControl $control, $range)
@@ -153,6 +155,8 @@ class Validator
 
 	/**
 	 * Is a control's value number greater than or equal to the specified minimum?
+	 * @param  IControl
+	 * @param  float
 	 * @return bool
 	 */
 	public static function validateMin(IControl $control, $minimum)
@@ -163,6 +167,8 @@ class Validator
 
 	/**
 	 * Is a control's value number less than or equal to the specified maximum?
+	 * @param  IControl
+	 * @param  float
 	 * @return bool
 	 */
 	public static function validateMax(IControl $control, $maximum)
@@ -173,6 +179,8 @@ class Validator
 
 	/**
 	 * Count/length validator. Range is array, min and max length pair.
+	 * @param  IControl
+	 * @param  array|int
 	 * @return bool
 	 */
 	public static function validateLength(IControl $control, $range)
@@ -187,6 +195,8 @@ class Validator
 
 	/**
 	 * Has control's value minimal count/length?
+	 * @param  IControl
+	 * @param  int
 	 * @return bool
 	 */
 	public static function validateMinLength(IControl $control, $length)
@@ -197,6 +207,8 @@ class Validator
 
 	/**
 	 * Is control's value count/length in limit?
+	 * @param  IControl
+	 * @param  int
 	 * @return bool
 	 */
 	public static function validateMaxLength(IControl $control, $length)
@@ -244,6 +256,7 @@ class Validator
 
 	/**
 	 * Matches control's value regular expression?
+	 * @param  string
 	 * @return bool
 	 */
 	public static function validatePattern(IControl $control, $pattern)
@@ -285,6 +298,7 @@ class Validator
 
 	/**
 	 * Is file size in limit?
+	 * @param  int
 	 * @return bool
 	 */
 	public static function validateFileSize(Controls\UploadControl $control, $limit)
@@ -300,6 +314,8 @@ class Validator
 
 	/**
 	 * Has file specified mime type?
+	 * @param  IControl
+	 * @param  string|string[]
 	 * @return bool
 	 */
 	public static function validateMimeType(Controls\UploadControl $control, $mimeType)

--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -181,7 +181,7 @@ class Validator
 			$range = [$range, $range];
 		}
 		$value = $control->getValue();
-		return Validators::isInRange(is_array($value) ? count($value) : Strings::length($value), $range);
+		return Validators::isInRange(is_array($value) ? count($value) : Strings::length((string) $value), $range);
 	}
 
 

--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -26,710 +26,710 @@
 
 }(typeof window !== 'undefined' ? window : this, function(window) {
 
-'use strict';
+	'use strict';
 
-var Nette = {};
-
-Nette.formErrors = [];
-Nette.version = '2.4';
-
-
-/**
- * Attaches a handler to an event for the element.
- */
-Nette.addEvent = function(element, on, callback) {
-	if (element.addEventListener) {
-		element.addEventListener(on, callback);
-	} else if (on === 'DOMContentLoaded') {
-		element.attachEvent('onreadystatechange', function() {
-			if (element.readyState === 'complete') {
-				callback.call(this);
-			}
-		});
-	} else {
-		element.attachEvent('on' + on, getHandler(callback));
-	}
-};
-
-
-function getHandler(callback) {
-	return function(e) {
-		return callback.call(this, e);
-	};
-}
-
-
-/**
- * Returns the value of form element.
- */
-Nette.getValue = function(elem) {
-	var i;
-	if (!elem) {
-		return null;
-
-	} else if (!elem.tagName) { // RadioNodeList, HTMLCollection, array
-		return elem[0] ? Nette.getValue(elem[0]) : null;
-
-	} else if (elem.type === 'radio') {
-		var elements = elem.form.elements; // prevents problem with name 'item' or 'namedItem'
-		for (i = 0; i < elements.length; i++) {
-			if (elements[i].name === elem.name && elements[i].checked) {
-				return elements[i].value;
-			}
-		}
-		return null;
-
-	} else if (elem.type === 'file') {
-		return elem.files || elem.value;
-
-	} else if (elem.tagName.toLowerCase() === 'select') {
-		var index = elem.selectedIndex,
-			options = elem.options,
-			values = [];
-
-		if (elem.type === 'select-one') {
-			return index < 0 ? null : options[index].value;
-		}
-
-		for (i = 0; i < options.length; i++) {
-			if (options[i].selected) {
-				values.push(options[i].value);
-			}
-		}
-		return values;
-
-	} else if (elem.name && elem.name.match(/\[\]$/)) { // multiple elements []
-		var elements = elem.form.elements[elem.name].tagName ? [elem] : elem.form.elements[elem.name],
-			values = [];
-
-		for (i = 0; i < elements.length; i++) {
-			if (elements[i].type !== 'checkbox' || elements[i].checked) {
-				values.push(elements[i].value);
-			}
-		}
-		return values;
-
-	} else if (elem.type === 'checkbox') {
-		return elem.checked;
-
-	} else if (elem.tagName.toLowerCase() === 'textarea') {
-		return elem.value.replace('\r', '');
-
-	} else {
-		return elem.value.replace('\r', '').replace(/^\s+|\s+$/g, '');
-	}
-};
-
-
-/**
- * Returns the effective value of form element.
- */
-Nette.getEffectiveValue = function(elem) {
-	var val = Nette.getValue(elem);
-	if (elem.getAttribute) {
-		if (val === elem.getAttribute('data-nette-empty-value')) {
-			val = '';
-		}
-	}
-	return val;
-};
-
-
-/**
- * Validates form element against given rules.
- */
-Nette.validateControl = function(elem, rules, onlyCheck, value, emptyOptional) {
-	elem = elem.tagName ? elem : elem[0]; // RadioNodeList
-	rules = rules || Nette.parseJSON(elem.getAttribute('data-nette-rules'));
-	value = value === undefined ? {value: Nette.getEffectiveValue(elem)} : value;
-
-	for (var id = 0, len = rules.length; id < len; id++) {
-		var rule = rules[id],
-			op = rule.op.match(/(~)?([^?]+)/),
-			curElem = rule.control ? elem.form.elements.namedItem(rule.control) : elem;
-
-		rule.neg = op[1];
-		rule.op = op[2];
-		rule.condition = !!rule.rules;
-
-		if (!curElem) {
-			continue;
-		} else if (rule.op === 'optional') {
-			emptyOptional = !Nette.validateRule(elem, ':filled', null, value);
-			continue;
-		} else if (emptyOptional && !rule.condition && rule.op !== ':filled') {
-			continue;
-		}
-
-		curElem = curElem.tagName ? curElem : curElem[0]; // RadioNodeList
-		var curValue = elem === curElem ? value : {value: Nette.getEffectiveValue(curElem)},
-			success = Nette.validateRule(curElem, rule.op, rule.arg, curValue);
-
-		if (success === null) {
-			continue;
-		} else if (rule.neg) {
-			success = !success;
-		}
-
-		if (rule.condition && success) {
-			if (!Nette.validateControl(elem, rule.rules, onlyCheck, value, rule.op === ':blank' ? false : emptyOptional)) {
-				return false;
-			}
-		} else if (!rule.condition && !success) {
-			if (Nette.isDisabled(curElem)) {
-				continue;
-			}
-			if (!onlyCheck) {
-				var arr = Nette.isArray(rule.arg) ? rule.arg : [rule.arg],
-					message = rule.msg.replace(/%(value|\d+)/g, function(foo, m) {
-						return Nette.getValue(m === 'value' ? curElem : elem.form.elements.namedItem(arr[m].control));
-					});
-				Nette.addError(curElem, message);
-			}
-			return false;
-		}
-	}
-
-	if (elem.type === 'number' && !elem.validity.valid) {
-		if (!onlyCheck) {
-			Nette.addError(elem, 'Please enter a valid value.');
-		}
-		return false;
-	}
-
-	return true;
-};
-
-
-/**
- * Validates whole form.
- */
-Nette.validateForm = function(sender, onlyCheck) {
-	var form = sender.form || sender,
-		scope = false;
+	var Nette = {};
 
 	Nette.formErrors = [];
+	Nette.version = '2.4';
 
-	if (form['nette-submittedBy'] && form['nette-submittedBy'].getAttribute('formnovalidate') !== null) {
-		var scopeArr = Nette.parseJSON(form['nette-submittedBy'].getAttribute('data-nette-validation-scope'));
-		if (scopeArr.length) {
-			scope = new RegExp('^(' + scopeArr.join('-|') + '-)');
+
+	/**
+	 * Attaches a handler to an event for the element.
+	 */
+	Nette.addEvent = function(element, on, callback) {
+		if (element.addEventListener) {
+			element.addEventListener(on, callback);
+		} else if (on === 'DOMContentLoaded') {
+			element.attachEvent('onreadystatechange', function() {
+				if (element.readyState === 'complete') {
+					callback.call(this);
+				}
+			});
 		} else {
-			Nette.showFormErrors(form, []);
-			return true;
+			element.attachEvent('on' + on, getHandler(callback));
 		}
+	};
+
+
+	function getHandler(callback) {
+		return function(e) {
+			return callback.call(this, e);
+		};
 	}
 
-	var radios = {}, i, elem;
 
-	for (i = 0; i < form.elements.length; i++) {
-		elem = form.elements[i];
+	/**
+	 * Returns the value of form element.
+	 */
+	Nette.getValue = function(elem) {
+		var i;
+		if (!elem) {
+			return null;
 
-		if (elem.tagName && !(elem.tagName.toLowerCase() in {input: 1, select: 1, textarea: 1, button: 1})) {
-			continue;
+		} else if (!elem.tagName) { // RadioNodeList, HTMLCollection, array
+			return elem[0] ? Nette.getValue(elem[0]) : null;
 
 		} else if (elem.type === 'radio') {
-			if (radios[elem.name]) {
-				continue;
+			var elements = elem.form.elements; // prevents problem with name 'item' or 'namedItem'
+			for (i = 0; i < elements.length; i++) {
+				if (elements[i].name === elem.name && elements[i].checked) {
+					return elements[i].value;
+				}
 			}
-			radios[elem.name] = true;
-		}
-
-		if ((scope && !elem.name.replace(/]\[|\[|]|$/g, '-').match(scope)) || Nette.isDisabled(elem)) {
-			continue;
-		}
-
-		if (!Nette.validateControl(elem, null, onlyCheck) && !Nette.formErrors.length) {
-			return false;
-		}
-	}
-	var success = !Nette.formErrors.length;
-	Nette.showFormErrors(form, Nette.formErrors);
-	return success;
-};
-
-
-/**
- * Check if input is disabled.
- */
-Nette.isDisabled = function(elem) {
-	if (elem.type === 'radio') {
-		for (var i = 0, elements = elem.form.elements; i < elements.length; i++) {
-			if (elements[i].name === elem.name && !elements[i].disabled) {
-				return false;
-			}
-		}
-		return true;
-	}
-	return elem.disabled;
-};
-
-
-/**
- * Adds error message to the queue.
- */
-Nette.addError = function(elem, message) {
-	Nette.formErrors.push({
-		element: elem,
-		message: message
-	});
-};
-
-
-/**
- * Display error messages.
- */
-Nette.showFormErrors = function(form, errors) {
-	var messages = [],
-		focusElem;
-
-	for (var i = 0; i < errors.length; i++) {
-		var elem = errors[i].element,
-			message = errors[i].message;
-
-		if (!Nette.inArray(messages, message)) {
-			messages.push(message);
-
-			if (!focusElem && elem.focus) {
-				focusElem = elem;
-			}
-		}
-	}
-
-	if (messages.length) {
-		alert(messages.join('\n'));
-
-		if (focusElem) {
-			focusElem.focus();
-		}
-	}
-};
-
-
-/**
- * Expand rule argument.
- */
-Nette.expandRuleArgument = function(form, arg) {
-	if (arg && arg.control) {
-		var control = form.elements.namedItem(arg.control),
-			value = {value: Nette.getEffectiveValue(control)};
-		Nette.validateControl(control, null, true, value);
-		arg = value.value;
-	}
-	return arg;
-};
-
-
-/**
- * Validates single rule.
- */
-Nette.validateRule = function(elem, op, arg, value) {
-	value = value === undefined ? {value: Nette.getEffectiveValue(elem)} : value;
-
-	if (op.charAt(0) === ':') {
-		op = op.substr(1);
-	}
-	op = op.replace('::', '_');
-	op = op.replace(/\\/g, '');
-
-	var arr = Nette.isArray(arg) ? arg.slice(0) : [arg];
-	for (var i = 0, len = arr.length; i < len; i++) {
-		arr[i] = Nette.expandRuleArgument(elem.form, arr[i]);
-	}
-	return Nette.validators[op]
-		? Nette.validators[op](elem, Nette.isArray(arg) ? arr : arr[0], value.value, value)
-		: null;
-};
-
-
-Nette.validators = {
-	filled: function(elem, arg, val) {
-		if (elem.type === 'number' && elem.validity.badInput) {
-			return true;
-		}
-		return val !== '' && val !== false && val !== null
-			&& (!Nette.isArray(val) || !!val.length)
-			&& (!window.FileList || !(val instanceof window.FileList) || val.length);
-	},
-
-	blank: function(elem, arg, val) {
-		return !Nette.validators.filled(elem, arg, val);
-	},
-
-	valid: function(elem) {
-		return Nette.validateControl(elem, null, true);
-	},
-
-	equal: function(elem, arg, val) {
-		if (arg === undefined) {
 			return null;
-		}
 
-		function toString(val) {
-			if (typeof val === 'number' || typeof val === 'string') {
-				return '' + val;
-			} else {
-				return val === true ? '1' : '';
+		} else if (elem.type === 'file') {
+			return elem.files || elem.value;
+
+		} else if (elem.tagName.toLowerCase() === 'select') {
+			var index = elem.selectedIndex,
+				options = elem.options,
+				values = [];
+
+			if (elem.type === 'select-one') {
+				return index < 0 ? null : options[index].value;
 			}
-		}
 
-		val = Nette.isArray(val) ? val : [val];
-		arg = Nette.isArray(arg) ? arg : [arg];
-		loop:
-		for (var i1 = 0, len1 = val.length; i1 < len1; i1++) {
-			for (var i2 = 0, len2 = arg.length; i2 < len2; i2++) {
-				if (toString(val[i1]) === toString(arg[i2])) {
-					continue loop;
+			for (i = 0; i < options.length; i++) {
+				if (options[i].selected) {
+					values.push(options[i].value);
 				}
 			}
-			return false;
-		}
-		return true;
-	},
+			return values;
 
-	notEqual: function(elem, arg, val) {
-		return arg === undefined ? null : !Nette.validators.equal(elem, arg, val);
-	},
+		} else if (elem.name && elem.name.match(/\[\]$/)) { // multiple elements []
+			var elements = elem.form.elements[elem.name].tagName ? [elem] : elem.form.elements[elem.name],
+				values = [];
 
-	minLength: function(elem, arg, val) {
-		if (elem.type === 'number') {
-			if (elem.validity.tooShort) {
-				return false;
-			} else if (elem.validity.badInput) {
-				return null;
-			}
-		}
-		return val.length >= arg;
-	},
-
-	maxLength: function(elem, arg, val) {
-		if (elem.type === 'number') {
-			if (elem.validity.tooLong) {
-				return false;
-			} else if (elem.validity.badInput) {
-				return null;
-			}
-		}
-		return val.length <= arg;
-	},
-
-	length: function(elem, arg, val) {
-		if (elem.type === 'number') {
-			if (elem.validity.tooShort || elem.validity.tooLong) {
-				return false;
-			} else if (elem.validity.badInput) {
-				return null;
-			}
-		}
-		arg = Nette.isArray(arg) ? arg : [arg, arg];
-		return (arg[0] === null || val.length >= arg[0]) && (arg[1] === null || val.length <= arg[1]);
-	},
-
-	email: function(elem, arg, val) {
-		return (/^("([ !#-[\]-~]|\\[ -~])+"|[-a-z0-9!#$%&'*+\/=?^_`{|}~]+(\.[-a-z0-9!#$%&'*+\/=?^_`{|}~]+)*)@([0-9a-z\u00C0-\u02FF\u0370-\u1EFF]([-0-9a-z\u00C0-\u02FF\u0370-\u1EFF]{0,61}[0-9a-z\u00C0-\u02FF\u0370-\u1EFF])?\.)+[a-z\u00C0-\u02FF\u0370-\u1EFF]([-0-9a-z\u00C0-\u02FF\u0370-\u1EFF]{0,17}[a-z\u00C0-\u02FF\u0370-\u1EFF])?$/i).test(val);
-	},
-
-	url: function(elem, arg, val, value) {
-		if (!(/^[a-z\d+.-]+:/).test(val)) {
-			val = 'http://' + val;
-		}
-		if ((/^https?:\/\/((([-_0-9a-z\u00C0-\u02FF\u0370-\u1EFF]+\.)*[0-9a-z\u00C0-\u02FF\u0370-\u1EFF]([-0-9a-z\u00C0-\u02FF\u0370-\u1EFF]{0,61}[0-9a-z\u00C0-\u02FF\u0370-\u1EFF])?\.)?[a-z\u00C0-\u02FF\u0370-\u1EFF]([-0-9a-z\u00C0-\u02FF\u0370-\u1EFF]{0,17}[a-z\u00C0-\u02FF\u0370-\u1EFF])?|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[0-9a-f:]{3,39}\])(:\d{1,5})?(\/\S*)?$/i).test(val)) {
-			value.value = val;
-			return true;
-		}
-		return false;
-	},
-
-	regexp: function(elem, arg, val) {
-		var parts = typeof arg === 'string' ? arg.match(/^\/(.*)\/([imu]*)$/) : false;
-		try {
-			return parts && (new RegExp(parts[1], parts[2].replace('u', ''))).test(val);
-		} catch (e) {}
-	},
-
-	pattern: function(elem, arg, val) {
-		try {
-			return typeof arg === 'string' ? (new RegExp('^(?:' + arg + ')$')).test(val) : null;
-		} catch (e) {}
-	},
-
-	integer: function(elem, arg, val) {
-		if (elem.type === 'number' && elem.validity.badInput) {
-			return false;
-		}
-		return (/^-?[0-9]+$/).test(val);
-	},
-
-	'float': function(elem, arg, val, value) {
-		if (elem.type === 'number' && elem.validity.badInput) {
-			return false;
-		}
-		val = val.replace(' ', '').replace(',', '.');
-		if ((/^-?[0-9]*[.,]?[0-9]+$/).test(val)) {
-			value.value = val;
-			return true;
-		}
-		return false;
-	},
-
-	min: function(elem, arg, val) {
-		if (elem.type === 'number') {
-			if (elem.validity.rangeUnderflow) {
-				return false;
-			} else if (elem.validity.badInput) {
-				return null;
-			}
-		}
-		return arg === null || parseFloat(val) >= arg;
-	},
-
-	max: function(elem, arg, val) {
-		if (elem.type === 'number') {
-			if (elem.validity.rangeOverflow) {
-				return false;
-			} else if (elem.validity.badInput) {
-				return null;
-			}
-		}
-		return arg === null || parseFloat(val) <= arg;
-	},
-
-	range: function(elem, arg, val) {
-		if (elem.type === 'number') {
-			if (elem.validity.rangeUnderflow || elem.validity.rangeOverflow) {
-				return false;
-			} else if (elem.validity.badInput) {
-				return null;
-			}
-		}
-		return Nette.isArray(arg) ?
-			((arg[0] === null || parseFloat(val) >= arg[0]) && (arg[1] === null || parseFloat(val) <= arg[1])) : null;
-	},
-
-	submitted: function(elem) {
-		return elem.form['nette-submittedBy'] === elem;
-	},
-
-	fileSize: function(elem, arg, val) {
-		if (window.FileList) {
-			for (var i = 0; i < val.length; i++) {
-				if (val[i].size > arg) {
-					return false;
+			for (i = 0; i < elements.length; i++) {
+				if (elements[i].type !== 'checkbox' || elements[i].checked) {
+					values.push(elements[i].value);
 				}
 			}
-		}
-		return true;
-	},
+			return values;
 
-	image: function (elem, arg, val) {
-		if (window.FileList && val instanceof window.FileList) {
-			for (var i = 0; i < val.length; i++) {
-				var type = val[i].type;
-				if (type && type !== 'image/gif' && type !== 'image/png' && type !== 'image/jpeg') {
-					return false;
-				}
+		} else if (elem.type === 'checkbox') {
+			return elem.checked;
+
+		} else if (elem.tagName.toLowerCase() === 'textarea') {
+			return elem.value.replace('\r', '');
+
+		} else {
+			return elem.value.replace('\r', '').replace(/^\s+|\s+$/g, '');
+		}
+	};
+
+
+	/**
+	 * Returns the effective value of form element.
+	 */
+	Nette.getEffectiveValue = function(elem) {
+		var val = Nette.getValue(elem);
+		if (elem.getAttribute) {
+			if (val === elem.getAttribute('data-nette-empty-value')) {
+				val = '';
 			}
 		}
-		return true;
-	}
-};
+		return val;
+	};
 
 
-/**
- * Process all toggles in form.
- */
-Nette.toggleForm = function(form, elem) {
-	var i;
-	Nette.toggles = {};
-	for (i = 0; i < form.elements.length; i++) {
-		if (form.elements[i].tagName.toLowerCase() in {input: 1, select: 1, textarea: 1, button: 1}) {
-			Nette.toggleControl(form.elements[i], null, null, !elem);
-		}
-	}
+	/**
+	 * Validates form element against given rules.
+	 */
+	Nette.validateControl = function(elem, rules, onlyCheck, value, emptyOptional) {
+		elem = elem.tagName ? elem : elem[0]; // RadioNodeList
+		rules = rules || Nette.parseJSON(elem.getAttribute('data-nette-rules'));
+		value = value === undefined ? {value: Nette.getEffectiveValue(elem)} : value;
 
-	for (i in Nette.toggles) {
-		Nette.toggle(i, Nette.toggles[i], elem);
-	}
-};
+		for (var id = 0, len = rules.length; id < len; id++) {
+			var rule = rules[id],
+				op = rule.op.match(/(~)?([^?]+)/),
+				curElem = rule.control ? elem.form.elements.namedItem(rule.control) : elem;
 
-
-/**
- * Process toggles on form element.
- */
-Nette.toggleControl = function(elem, rules, success, firsttime, value) {
-	rules = rules || Nette.parseJSON(elem.getAttribute('data-nette-rules'));
-	value = value === undefined ? {value: Nette.getEffectiveValue(elem)} : value;
-
-	var has = false,
-		handled = [],
-		handler = function () {
-			Nette.toggleForm(elem.form, elem);
-		},
-		curSuccess;
-
-	for (var id = 0, len = rules.length; id < len; id++) {
-		var rule = rules[id],
-			op = rule.op.match(/(~)?([^?]+)/),
-			curElem = rule.control ? elem.form.elements.namedItem(rule.control) : elem;
-
-		if (!curElem) {
-			continue;
-		}
-
-		curSuccess = success;
-		if (success !== false) {
 			rule.neg = op[1];
 			rule.op = op[2];
-			var curValue = elem === curElem ? value : {value: Nette.getEffectiveValue(curElem)};
-			curSuccess = Nette.validateRule(curElem, rule.op, rule.arg, curValue);
-			if (curSuccess === null) {
+			rule.condition = !!rule.rules;
+
+			if (!curElem) {
 				continue;
+			} else if (rule.op === 'optional') {
+				emptyOptional = !Nette.validateRule(elem, ':filled', null, value);
+				continue;
+			} else if (emptyOptional && !rule.condition && rule.op !== ':filled') {
+				continue;
+			}
 
+			curElem = curElem.tagName ? curElem : curElem[0]; // RadioNodeList
+			var curValue = elem === curElem ? value : {value: Nette.getEffectiveValue(curElem)},
+				success = Nette.validateRule(curElem, rule.op, rule.arg, curValue);
+
+			if (success === null) {
+				continue;
 			} else if (rule.neg) {
-				curSuccess = !curSuccess;
+				success = !success;
 			}
-			if (!rule.rules) {
-				success = curSuccess;
+
+			if (rule.condition && success) {
+				if (!Nette.validateControl(elem, rule.rules, onlyCheck, value, rule.op === ':blank' ? false : emptyOptional)) {
+					return false;
+				}
+			} else if (!rule.condition && !success) {
+				if (Nette.isDisabled(curElem)) {
+					continue;
+				}
+				if (!onlyCheck) {
+					var arr = Nette.isArray(rule.arg) ? rule.arg : [rule.arg],
+						message = rule.msg.replace(/%(value|\d+)/g, function(foo, m) {
+							return Nette.getValue(m === 'value' ? curElem : elem.form.elements.namedItem(arr[m].control));
+						});
+					Nette.addError(curElem, message);
+				}
+				return false;
 			}
 		}
 
-		if ((rule.rules && Nette.toggleControl(elem, rule.rules, curSuccess, firsttime, value)) || rule.toggle) {
-			has = true;
-			if (firsttime) {
-				var oldIE = !document.addEventListener, // IE < 9
-					name = curElem.tagName ? curElem.name : curElem[0].name,
-					els = curElem.tagName ? curElem.form.elements : curElem;
-
-				for (var i = 0; i < els.length; i++) {
-					if (els[i].name === name && !Nette.inArray(handled, els[i])) {
-						Nette.addEvent(els[i], oldIE && els[i].type in {checkbox: 1, radio: 1} ? 'click' : 'change', handler);
-						handled.push(els[i]);
-					}
-				}
+		if (elem.type === 'number' && !elem.validity.valid) {
+			if (!onlyCheck) {
+				Nette.addError(elem, 'Please enter a valid value.');
 			}
-			for (var id2 in rule.toggle || []) {
-				if (Object.prototype.hasOwnProperty.call(rule.toggle, id2)) {
-					Nette.toggles[id2] = Nette.toggles[id2] || (rule.toggle[id2] ? curSuccess : !curSuccess);
-				}
-			}
-		}
-	}
-	return has;
-};
-
-
-Nette.parseJSON = function(s) {
-	return (s || '').substr(0, 3) === '{op'
-		? eval('[' + s + ']') // backward compatibility with Nette 2.0.x
-		: JSON.parse(s || '[]');
-};
-
-
-/**
- * Displays or hides HTML element.
- */
-Nette.toggle = function(id, visible, srcElement) {
-	var elem = document.getElementById(id);
-	if (elem) {
-		elem.style.display = visible ? '' : 'none';
-	}
-};
-
-
-/**
- * Setup handlers.
- */
-Nette.initForm = function(form) {
-	Nette.toggleForm(form);
-
-	if (form.noValidate) {
-		return;
-	}
-
-	form.noValidate = true;
-
-	Nette.addEvent(form, 'submit', function(e) {
-		if (!Nette.validateForm(form)) {
-			if (e && e.stopPropagation) {
-				e.stopPropagation();
-				e.preventDefault();
-			} else if (window.event) {
-				event.cancelBubble = true;
-				event.returnValue = false;
-			}
-		}
-	});
-};
-
-
-/**
- * @private
- */
-Nette.initOnLoad = function() {
-	Nette.addEvent(document, 'DOMContentLoaded', function() {
-		for (var i = 0; i < document.forms.length; i++) {
-			var form = document.forms[i];
-			for (var j = 0; j < form.elements.length; j++) {
-				if (form.elements[j].getAttribute('data-nette-rules')) {
-					Nette.initForm(form);
-					break;
-				}
-			}
+			return false;
 		}
 
-		Nette.addEvent(document.body, 'click', function(e) {
-			var target = e.target || e.srcElement;
-			while (target) {
-				if (target.form && target.type in {submit: 1, image: 1}) {
-					target.form['nette-submittedBy'] = target;
-					break;
-				}
-				target = target.parentNode;
-			}
-		});
-	});
-};
+		return true;
+	};
 
 
-/**
- * Determines whether the argument is an array.
- */
-Nette.isArray = function(arg) {
-	return Object.prototype.toString.call(arg) === '[object Array]';
-};
+	/**
+	 * Validates whole form.
+	 */
+	Nette.validateForm = function(sender, onlyCheck) {
+		var form = sender.form || sender,
+			scope = false;
 
+		Nette.formErrors = [];
 
-/**
- * Search for a specified value within an array.
- */
-Nette.inArray = function(arr, val) {
-	if ([].indexOf) {
-		return arr.indexOf(val) > -1;
-	} else {
-		for (var i = 0; i < arr.length; i++) {
-			if (arr[i] === val) {
+		if (form['nette-submittedBy'] && form['nette-submittedBy'].getAttribute('formnovalidate') !== null) {
+			var scopeArr = Nette.parseJSON(form['nette-submittedBy'].getAttribute('data-nette-validation-scope'));
+			if (scopeArr.length) {
+				scope = new RegExp('^(' + scopeArr.join('-|') + '-)');
+			} else {
+				Nette.showFormErrors(form, []);
 				return true;
 			}
 		}
-		return false;
-	}
-};
+
+		var radios = {}, i, elem;
+
+		for (i = 0; i < form.elements.length; i++) {
+			elem = form.elements[i];
+
+			if (elem.tagName && !(elem.tagName.toLowerCase() in {input: 1, select: 1, textarea: 1, button: 1})) {
+				continue;
+
+			} else if (elem.type === 'radio') {
+				if (radios[elem.name]) {
+					continue;
+				}
+				radios[elem.name] = true;
+			}
+
+			if ((scope && !elem.name.replace(/]\[|\[|]|$/g, '-').match(scope)) || Nette.isDisabled(elem)) {
+				continue;
+			}
+
+			if (!Nette.validateControl(elem, null, onlyCheck) && !Nette.formErrors.length) {
+				return false;
+			}
+		}
+		var success = !Nette.formErrors.length;
+		Nette.showFormErrors(form, Nette.formErrors);
+		return success;
+	};
 
 
-/**
- * Converts string to web safe characters [a-z0-9-] text.
- */
-Nette.webalize = function(s) {
-	s = s.toLowerCase();
-	var res = '', i, ch;
-	for (i = 0; i < s.length; i++) {
-		ch = Nette.webalizeTable[s.charAt(i)];
-		res += ch ? ch : s.charAt(i);
-	}
-	return res.replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-};
+	/**
+	 * Check if input is disabled.
+	 */
+	Nette.isDisabled = function(elem) {
+		if (elem.type === 'radio') {
+			for (var i = 0, elements = elem.form.elements; i < elements.length; i++) {
+				if (elements[i].name === elem.name && !elements[i].disabled) {
+					return false;
+				}
+			}
+			return true;
+		}
+		return elem.disabled;
+	};
 
-Nette.webalizeTable = {\u00e1: 'a', \u00e4: 'a', \u010d: 'c', \u010f: 'd', \u00e9: 'e', \u011b: 'e', \u00ed: 'i', \u013e: 'l', \u0148: 'n', \u00f3: 'o', \u00f4: 'o', \u0159: 'r', \u0161: 's', \u0165: 't', \u00fa: 'u', \u016f: 'u', \u00fd: 'y', \u017e: 'z'};
 
-return Nette;
+	/**
+	 * Adds error message to the queue.
+	 */
+	Nette.addError = function(elem, message) {
+		Nette.formErrors.push({
+			element: elem,
+			message: message
+		});
+	};
+
+
+	/**
+	 * Display error messages.
+	 */
+	Nette.showFormErrors = function(form, errors) {
+		var messages = [],
+			focusElem;
+
+		for (var i = 0; i < errors.length; i++) {
+			var elem = errors[i].element,
+				message = errors[i].message;
+
+			if (!Nette.inArray(messages, message)) {
+				messages.push(message);
+
+				if (!focusElem && elem.focus) {
+					focusElem = elem;
+				}
+			}
+		}
+
+		if (messages.length) {
+			alert(messages.join('\n'));
+
+			if (focusElem) {
+				focusElem.focus();
+			}
+		}
+	};
+
+
+	/**
+	 * Expand rule argument.
+	 */
+	Nette.expandRuleArgument = function(form, arg) {
+		if (arg && arg.control) {
+			var control = form.elements.namedItem(arg.control),
+				value = {value: Nette.getEffectiveValue(control)};
+			Nette.validateControl(control, null, true, value);
+			arg = value.value;
+		}
+		return arg;
+	};
+
+
+	/**
+	 * Validates single rule.
+	 */
+	Nette.validateRule = function(elem, op, arg, value) {
+		value = value === undefined ? {value: Nette.getEffectiveValue(elem)} : value;
+
+		if (op.charAt(0) === ':') {
+			op = op.substr(1);
+		}
+		op = op.replace('::', '_');
+		op = op.replace(/\\/g, '');
+
+		var arr = Nette.isArray(arg) ? arg.slice(0) : [arg];
+		for (var i = 0, len = arr.length; i < len; i++) {
+			arr[i] = Nette.expandRuleArgument(elem.form, arr[i]);
+		}
+		return Nette.validators[op]
+			? Nette.validators[op](elem, Nette.isArray(arg) ? arr : arr[0], value.value, value)
+			: null;
+	};
+
+
+	Nette.validators = {
+		filled: function(elem, arg, val) {
+			if (elem.type === 'number' && elem.validity.badInput) {
+				return true;
+			}
+			return val !== '' && val !== false && val !== null
+				&& (!Nette.isArray(val) || !!val.length)
+				&& (!window.FileList || !(val instanceof window.FileList) || val.length);
+		},
+
+		blank: function(elem, arg, val) {
+			return !Nette.validators.filled(elem, arg, val);
+		},
+
+		valid: function(elem) {
+			return Nette.validateControl(elem, null, true);
+		},
+
+		equal: function(elem, arg, val) {
+			if (arg === undefined) {
+				return null;
+			}
+
+			function toString(val) {
+				if (typeof val === 'number' || typeof val === 'string') {
+					return '' + val;
+				} else {
+					return val === true ? '1' : '';
+				}
+			}
+
+			val = Nette.isArray(val) ? val : [val];
+			arg = Nette.isArray(arg) ? arg : [arg];
+			loop:
+			for (var i1 = 0, len1 = val.length; i1 < len1; i1++) {
+				for (var i2 = 0, len2 = arg.length; i2 < len2; i2++) {
+					if (toString(val[i1]) === toString(arg[i2])) {
+						continue loop;
+					}
+				}
+				return false;
+			}
+			return true;
+		},
+
+		notEqual: function(elem, arg, val) {
+			return arg === undefined ? null : !Nette.validators.equal(elem, arg, val);
+		},
+
+		minLength: function(elem, arg, val) {
+			if (elem.type === 'number') {
+				if (elem.validity.tooShort) {
+					return false;
+				} else if (elem.validity.badInput) {
+					return null;
+				}
+			}
+			return val.length >= arg;
+		},
+
+		maxLength: function(elem, arg, val) {
+			if (elem.type === 'number') {
+				if (elem.validity.tooLong) {
+					return false;
+				} else if (elem.validity.badInput) {
+					return null;
+				}
+			}
+			return val.length <= arg;
+		},
+
+		length: function(elem, arg, val) {
+			if (elem.type === 'number') {
+				if (elem.validity.tooShort || elem.validity.tooLong) {
+					return false;
+				} else if (elem.validity.badInput) {
+					return null;
+				}
+			}
+			arg = Nette.isArray(arg) ? arg : [arg, arg];
+			return (arg[0] === null || val.length >= arg[0]) && (arg[1] === null || val.length <= arg[1]);
+		},
+
+		email: function(elem, arg, val) {
+			return (/^("([ !#-[\]-~]|\\[ -~])+"|[-a-z0-9!#$%&'*+\/=?^_`{|}~]+(\.[-a-z0-9!#$%&'*+\/=?^_`{|}~]+)*)@([0-9a-z\u00C0-\u02FF\u0370-\u1EFF]([-0-9a-z\u00C0-\u02FF\u0370-\u1EFF]{0,61}[0-9a-z\u00C0-\u02FF\u0370-\u1EFF])?\.)+[a-z\u00C0-\u02FF\u0370-\u1EFF]([-0-9a-z\u00C0-\u02FF\u0370-\u1EFF]{0,17}[a-z\u00C0-\u02FF\u0370-\u1EFF])?$/i).test(val);
+		},
+
+		url: function(elem, arg, val, value) {
+			if (!(/^[a-z\d+.-]+:/).test(val)) {
+				val = 'http://' + val;
+			}
+			if ((/^https?:\/\/((([-_0-9a-z\u00C0-\u02FF\u0370-\u1EFF]+\.)*[0-9a-z\u00C0-\u02FF\u0370-\u1EFF]([-0-9a-z\u00C0-\u02FF\u0370-\u1EFF]{0,61}[0-9a-z\u00C0-\u02FF\u0370-\u1EFF])?\.)?[a-z\u00C0-\u02FF\u0370-\u1EFF]([-0-9a-z\u00C0-\u02FF\u0370-\u1EFF]{0,17}[a-z\u00C0-\u02FF\u0370-\u1EFF])?|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[[0-9a-f:]{3,39}\])(:\d{1,5})?(\/\S*)?$/i).test(val)) {
+				value.value = val;
+				return true;
+			}
+			return false;
+		},
+
+		regexp: function(elem, arg, val) {
+			var parts = typeof arg === 'string' ? arg.match(/^\/(.*)\/([imu]*)$/) : false;
+			try {
+				return parts && (new RegExp(parts[1], parts[2].replace('u', ''))).test(val);
+			} catch (e) {}
+		},
+
+		pattern: function(elem, arg, val) {
+			try {
+				return typeof arg === 'string' ? (new RegExp('^(?:' + arg + ')$')).test(val) : null;
+			} catch (e) {}
+		},
+
+		integer: function(elem, arg, val) {
+			if (elem.type === 'number' && elem.validity.badInput) {
+				return false;
+			}
+			return (/^-?[0-9]+$/).test(val);
+		},
+
+		'float': function(elem, arg, val, value) {
+			if (elem.type === 'number' && elem.validity.badInput) {
+				return false;
+			}
+			val = val.replace(' ', '').replace(',', '.');
+			if ((/^-?[0-9]*[.,]?[0-9]+$/).test(val)) {
+				value.value = val;
+				return true;
+			}
+			return false;
+		},
+
+		min: function(elem, arg, val) {
+			if (elem.type === 'number') {
+				if (elem.validity.rangeUnderflow) {
+					return false;
+				} else if (elem.validity.badInput) {
+					return null;
+				}
+			}
+			return arg === null || parseFloat(val) >= arg;
+		},
+
+		max: function(elem, arg, val) {
+			if (elem.type === 'number') {
+				if (elem.validity.rangeOverflow) {
+					return false;
+				} else if (elem.validity.badInput) {
+					return null;
+				}
+			}
+			return arg === null || parseFloat(val) <= arg;
+		},
+
+		range: function(elem, arg, val) {
+			if (elem.type === 'number') {
+				if (elem.validity.rangeUnderflow || elem.validity.rangeOverflow) {
+					return false;
+				} else if (elem.validity.badInput) {
+					return null;
+				}
+			}
+			return Nette.isArray(arg) ?
+				((arg[0] === null || parseFloat(val) >= arg[0]) && (arg[1] === null || parseFloat(val) <= arg[1])) : null;
+		},
+
+		submitted: function(elem) {
+			return elem.form['nette-submittedBy'] === elem;
+		},
+
+		fileSize: function(elem, arg, val) {
+			if (window.FileList) {
+				for (var i = 0; i < val.length; i++) {
+					if (val[i].size > arg) {
+						return false;
+					}
+				}
+			}
+			return true;
+		},
+
+		image: function (elem, arg, val) {
+			if (window.FileList && val instanceof window.FileList) {
+				for (var i = 0; i < val.length; i++) {
+					var type = val[i].type;
+					if (type && type !== 'image/gif' && type !== 'image/png' && type !== 'image/jpeg') {
+						return false;
+					}
+				}
+			}
+			return true;
+		}
+	};
+
+
+	/**
+	 * Process all toggles in form.
+	 */
+	Nette.toggleForm = function(form, elem) {
+		var i;
+		Nette.toggles = {};
+		for (i = 0; i < form.elements.length; i++) {
+			if (form.elements[i].tagName.toLowerCase() in {input: 1, select: 1, textarea: 1, button: 1}) {
+				Nette.toggleControl(form.elements[i], null, null, !elem);
+			}
+		}
+
+		for (i in Nette.toggles) {
+			Nette.toggle(i, Nette.toggles[i], elem);
+		}
+	};
+
+
+	/**
+	 * Process toggles on form element.
+	 */
+	Nette.toggleControl = function(elem, rules, success, firsttime, value) {
+		rules = rules || Nette.parseJSON(elem.getAttribute('data-nette-rules'));
+		value = value === undefined ? {value: Nette.getEffectiveValue(elem)} : value;
+
+		var has = false,
+			handled = [],
+			handler = function () {
+				Nette.toggleForm(elem.form, elem);
+			},
+			curSuccess;
+
+		for (var id = 0, len = rules.length; id < len; id++) {
+			var rule = rules[id],
+				op = rule.op.match(/(~)?([^?]+)/),
+				curElem = rule.control ? elem.form.elements.namedItem(rule.control) : elem;
+
+			if (!curElem) {
+				continue;
+			}
+
+			curSuccess = success;
+			if (success !== false) {
+				rule.neg = op[1];
+				rule.op = op[2];
+				var curValue = elem === curElem ? value : {value: Nette.getEffectiveValue(curElem)};
+				curSuccess = Nette.validateRule(curElem, rule.op, rule.arg, curValue);
+				if (curSuccess === null) {
+					continue;
+
+				} else if (rule.neg) {
+					curSuccess = !curSuccess;
+				}
+				if (!rule.rules) {
+					success = curSuccess;
+				}
+			}
+
+			if ((rule.rules && Nette.toggleControl(elem, rule.rules, curSuccess, firsttime, value)) || rule.toggle) {
+				has = true;
+				if (firsttime) {
+					var oldIE = !document.addEventListener, // IE < 9
+						name = curElem.tagName ? curElem.name : curElem[0].name,
+						els = curElem.tagName ? curElem.form.elements : curElem;
+
+					for (var i = 0; i < els.length; i++) {
+						if (els[i].name === name && !Nette.inArray(handled, els[i])) {
+							Nette.addEvent(els[i], oldIE && els[i].type in {checkbox: 1, radio: 1} ? 'click' : 'change', handler);
+							handled.push(els[i]);
+						}
+					}
+				}
+				for (var id2 in rule.toggle || []) {
+					if (Object.prototype.hasOwnProperty.call(rule.toggle, id2)) {
+						Nette.toggles[id2] = Nette.toggles[id2] || (rule.toggle[id2] ? curSuccess : !curSuccess);
+					}
+				}
+			}
+		}
+		return has;
+	};
+
+
+	Nette.parseJSON = function(s) {
+		return (s || '').substr(0, 3) === '{op'
+			? eval('[' + s + ']') // backward compatibility with Nette 2.0.x
+			: JSON.parse(s || '[]');
+	};
+
+
+	/**
+	 * Displays or hides HTML element.
+	 */
+	Nette.toggle = function(id, visible, srcElement) {
+		var elem = document.getElementById(id);
+		if (elem) {
+			elem.style.display = visible ? '' : 'none';
+		}
+	};
+
+
+	/**
+	 * Setup handlers.
+	 */
+	Nette.initForm = function(form) {
+		Nette.toggleForm(form);
+
+		if (form.noValidate) {
+			return;
+		}
+
+		form.noValidate = true;
+
+		Nette.addEvent(form, 'submit', function(e) {
+			if (!Nette.validateForm(form)) {
+				if (e && e.stopPropagation) {
+					e.stopPropagation();
+					e.preventDefault();
+				} else if (window.event) {
+					event.cancelBubble = true;
+					event.returnValue = false;
+				}
+			}
+		});
+	};
+
+
+	/**
+	 * @private
+	 */
+	Nette.initOnLoad = function() {
+		Nette.addEvent(document, 'DOMContentLoaded', function() {
+			for (var i = 0; i < document.forms.length; i++) {
+				var form = document.forms[i];
+				for (var j = 0; j < form.elements.length; j++) {
+					if (form.elements[j].getAttribute('data-nette-rules')) {
+						Nette.initForm(form);
+						break;
+					}
+				}
+			}
+
+			Nette.addEvent(document.body, 'click', function(e) {
+				var target = e.target || e.srcElement;
+				while (target) {
+					if (target.form && target.type in {submit: 1, image: 1}) {
+						target.form['nette-submittedBy'] = target;
+						break;
+					}
+					target = target.parentNode;
+				}
+			});
+		});
+	};
+
+
+	/**
+	 * Determines whether the argument is an array.
+	 */
+	Nette.isArray = function(arg) {
+		return Object.prototype.toString.call(arg) === '[object Array]';
+	};
+
+
+	/**
+	 * Search for a specified value within an array.
+	 */
+	Nette.inArray = function(arr, val) {
+		if ([].indexOf) {
+			return arr.indexOf(val) > -1;
+		} else {
+			for (var i = 0; i < arr.length; i++) {
+				if (arr[i] === val) {
+					return true;
+				}
+			}
+			return false;
+		}
+	};
+
+
+	/**
+	 * Converts string to web safe characters [a-z0-9-] text.
+	 */
+	Nette.webalize = function(s) {
+		s = s.toLowerCase();
+		var res = '', i, ch;
+		for (i = 0; i < s.length; i++) {
+			ch = Nette.webalizeTable[s.charAt(i)];
+			res += ch ? ch : s.charAt(i);
+		}
+		return res.replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+	};
+
+	Nette.webalizeTable = {\u00e1: 'a', \u00e4: 'a', \u010d: 'c', \u010f: 'd', \u00e9: 'e', \u011b: 'e', \u00ed: 'i', \u013e: 'l', \u0148: 'n', \u00f3: 'o', \u00f4: 'o', \u0159: 'r', \u0161: 's', \u0165: 't', \u00fa: 'u', \u016f: 'u', \u00fd: 'y', \u017e: 'z'};
+
+	return Nette;
 }));

--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -113,10 +113,10 @@ Nette.getValue = function(elem) {
 		return elem.checked;
 
 	} else if (elem.tagName.toLowerCase() === 'textarea') {
-		return elem.value.replace("\r", '');
+		return elem.value.replace('\r', '');
 
 	} else {
-		return elem.value.replace("\r", '').replace(/^\s+|\s+$/g, '');
+		return elem.value.replace('\r', '').replace(/^\s+|\s+$/g, '');
 	}
 };
 
@@ -356,7 +356,7 @@ Nette.validators = {
 		return !Nette.validators.filled(elem, arg, val);
 	},
 
-	valid: function(elem, arg, val) {
+	valid: function(elem) {
 		return Nette.validateControl(elem, null, true);
 	},
 
@@ -394,7 +394,7 @@ Nette.validators = {
 	minLength: function(elem, arg, val) {
 		if (elem.type === 'number') {
 			if (elem.validity.tooShort) {
-				return false
+				return false;
 			} else if (elem.validity.badInput) {
 				return null;
 			}
@@ -405,7 +405,7 @@ Nette.validators = {
 	maxLength: function(elem, arg, val) {
 		if (elem.type === 'number') {
 			if (elem.validity.tooLong) {
-				return false
+				return false;
 			} else if (elem.validity.badInput) {
 				return null;
 			}
@@ -416,7 +416,7 @@ Nette.validators = {
 	length: function(elem, arg, val) {
 		if (elem.type === 'number') {
 			if (elem.validity.tooShort || elem.validity.tooLong) {
-				return false
+				return false;
 			} else if (elem.validity.badInput) {
 				return null;
 			}
@@ -475,7 +475,7 @@ Nette.validators = {
 	min: function(elem, arg, val) {
 		if (elem.type === 'number') {
 			if (elem.validity.rangeUnderflow) {
-				return false
+				return false;
 			} else if (elem.validity.badInput) {
 				return null;
 			}
@@ -486,7 +486,7 @@ Nette.validators = {
 	max: function(elem, arg, val) {
 		if (elem.type === 'number') {
 			if (elem.validity.rangeOverflow) {
-				return false
+				return false;
 			} else if (elem.validity.badInput) {
 				return null;
 			}
@@ -497,7 +497,7 @@ Nette.validators = {
 	range: function(elem, arg, val) {
 		if (elem.type === 'number') {
 			if (elem.validity.rangeUnderflow || elem.validity.rangeOverflow) {
-				return false
+				return false;
 			} else if (elem.validity.badInput) {
 				return null;
 			}
@@ -506,7 +506,7 @@ Nette.validators = {
 			((arg[0] === null || parseFloat(val) >= arg[0]) && (arg[1] === null || parseFloat(val) <= arg[1])) : null;
 	},
 
-	submitted: function(elem, arg, val) {
+	submitted: function(elem) {
 		return elem.form['nette-submittedBy'] === elem;
 	},
 

--- a/tests/Forms/Controls.MultiSelectBox.render.phpt
+++ b/tests/Forms/Controls.MultiSelectBox.render.phpt
@@ -76,6 +76,21 @@ test(function () { // Html with translator & groups
 });
 
 
+test(function () { // disabled translation
+	$form = new Form;
+	$input = $form->addMultiSelect('list', 'Label', [
+		'a' => 'First',
+		'group' => ['Second', 'Third'],
+	]);
+	$input->setTranslator(new Translator);
+	$input->setTranslateOptions(FALSE);
+
+	Assert::same('<label for="frm-list">LABEL</label>', (string) $input->getLabel());
+	Assert::same('<label for="frm-list">ANOTHER LABEL</label>', (string) $input->getLabel('Another label'));
+	Assert::same('<select name="list[]" id="frm-list" multiple><option value="a">First</option><optgroup label="group"><option value="0">Second</option><option value="1">Third</option></optgroup></select>', (string) $input->getControl());
+});
+
+
 test(function () { // validation rules
 	$form = new Form;
 	$input = $form->addMultiSelect('list', 'Label', [

--- a/tests/Forms/Controls.SelectBox.render.phpt
+++ b/tests/Forms/Controls.SelectBox.render.phpt
@@ -76,6 +76,21 @@ test(function () { // Html with translator & groups
 });
 
 
+test(function () { // disabled translation
+	$form = new Form;
+	$input = $form->addSelect('list', 'Label', [
+		'a' => 'First',
+		'group' => ['Second', 'Third'],
+	])->setPrompt('Prompt');
+	$input->setTranslator(new Translator);
+	$input->setTranslateOptions(FALSE);
+
+	Assert::same('<label for="frm-list">LABEL</label>', (string) $input->getLabel());
+	Assert::same('<label for="frm-list">ANOTHER LABEL</label>', (string) $input->getLabel('Another label'));
+	Assert::same('<select name="list" id="frm-list"><option value="">PROMPT</option><option value="a">First</option><optgroup label="group"><option value="0">Second</option><option value="1">Third</option></optgroup></select>', (string) $input->getControl());
+});
+
+
 test(function () { // validation rules
 	$form = new Form;
 	$input = $form->addSelect('list', 'Label', [


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no
- doc PR:

This will give us the option not to translate select options yet it will still translate the prompt. Why? I often use options which are not translatable (eg. project names, users, etc.) and I get a lot of issues from kdyby/translation which can shadow real issues I need to fix.

This will help me clear out error log to focus on just issues I need.
