### PR TITLE
Exclude :submit from validation

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -233,6 +233,8 @@
 					continue;
 				}
 				radios[elem.name] = true;
+			} else if (elem.type === 'submit') {
+				continue;
 			}
 
 			if ((scope && !elem.name.replace(/]\[|\[|]|$/g, '-').match(scope)) || Nette.isDisabled(elem)) {


### PR DESCRIPTION
Element :submit does not contain validation rules.

- bug fix? yes
- new feature? no
- BC break? no

