### PR TITLE
Fix compatibility between n:class macro and n:name form macro.

### DIFF
--- a/src/Bridges/FormsLatte/FormMacros.php
+++ b/src/Bridges/FormsLatte/FormMacros.php
@@ -165,6 +165,11 @@ class FormMacros extends MacroSet
 		$tagName = strtolower($node->htmlNode->name);
 		$node->empty = $tagName === 'input';
 
+		$definedHtmlAttributes = array_keys($node->htmlNode->attrs);
+		if (isset($node->htmlNode->macroAttrs['class'])) {
+			$definedHtmlAttributes[] = 'class';
+		}
+
 		if ($tagName === 'form') {
 			$node->openingCode = $writer->write(
 				'<?php $form = $_form = $this->global->formsStack[] = '
@@ -174,17 +179,17 @@ class FormMacros extends MacroSet
 			);
 			return $writer->write(
 				'echo Nette\Bridges\FormsLatte\Runtime::renderFormBegin(end($this->global->formsStack), %0.var, false)',
-				array_fill_keys(array_keys($node->htmlNode->attrs), null)
+				array_fill_keys($definedHtmlAttributes, null)
 			);
 		} else {
 			$method = $tagName === 'label' ? 'getLabel' : 'getControl';
 			return $writer->write(
 				'$_input = ' . ($name[0] === '$' ? 'is_object(%0.word) ? %0.word : ' : '')
 					. 'end($this->global->formsStack)[%0.word]; echo $_input->%1.raw'
-					. ($node->htmlNode->attrs ? '->addAttributes(%2.var)' : '') . '->attributes()',
+					. ($definedHtmlAttributes ? '->addAttributes(%2.var)' : '') . '->attributes()',
 				$name,
 				$method . 'Part(' . implode(', ', array_map([$writer, 'formatWord'], $words)) . ')',
-				array_fill_keys(array_keys($node->htmlNode->attrs), null)
+				array_fill_keys($definedHtmlAttributes, null)
 			);
 		}
 	}

--- a/tests/Forms.Latte/FormMacros.forms.phpt
+++ b/tests/Forms.Latte/FormMacros.forms.phpt
@@ -30,8 +30,10 @@ class MyControl extends Nette\Forms\Controls\BaseControl
 
 
 $form = new Form;
+$form->getElementPrototype()->addClass('form-class');
 $form->addHidden('id');
 $form->addText('username', 'Username:'); // must have just one textfield to generate IE fix
+$form['username']->getControlPrototype()->addClass('control-class');
 $form->addRadioList('sex', 'Sex:', ['m' => 'male', 'f' => 'female']);
 $form->addSelect('select', null, ['m' => 'male', 'f' => 'female']);
 $form->addTextArea('area', null)->setValue('one<two');

--- a/tests/Forms.Latte/expected/FormMacros.forms.html
+++ b/tests/Forms.Latte/expected/FormMacros.forms.html
@@ -1,4 +1,4 @@
-<form action="" method="post" id="myForm" class="ajax">
+<form action="" method="post" class="ajax" id="myForm">
 
 		<input type="hidden" name="id" value="" title="Hello" size="10">
 
@@ -9,13 +9,13 @@
 		 <input type="hidden" name="id" value="" title="Hello" size="10">
 
 		<label for="frm-username">Username:</label>
-		<input type="text" name="username" size="10" id="frm-username" title="Hello">
+		<input type="text" name="username" size="10" class="control-class" id="frm-username" title="Hello">
 		error
 		error
 
 		<br>
 
-		<label for="frm-username" title="hello"> <input type="text" name="username" size="10" id="frm-username" title="Hello"> </label>
+		<label for="frm-username" title="hello"> <input type="text" name="username" size="10" class="control-class" id="frm-username" title="Hello"> </label>
 		error
 		<label for="frm-select"></label>
 		<select name="select" size="10" id="frm-select" title="Hello"><option value="m">male</option><option value="f">female</option></select>
@@ -52,7 +52,7 @@
 
 	<label for="frm-username"></label>
 	<label for="frm-username">Username:</label>
-	<input type="text" name="username" id="frm-username">
+	<input type="text" name="username" class="control-class" id="frm-username">
 
 	<label>My</label><input name=My>
 <!--[if IE]><input type=IEbug disabled style="display:none"><![endif]-->
@@ -60,11 +60,11 @@
 
 
 
-<form action="" method="post"><input type="hidden" name="id" value=""><!--[if IE]><input type=IEbug disabled style="display:none"><![endif]-->
+<form action="" method="post" class="form-class"><input type="hidden" name="id" value=""><!--[if IE]><input type=IEbug disabled style="display:none"><![endif]-->
 </form>
 
 
-<form action="" method="post">
+<form action="" method="post" class="form-class">
 	<label for="frm-sex-m"> <input type="radio" name="sex" id="frm-sex-m" value="m"> male</label>
 	<label title=hello for="frm-sex-m"> <input type="radio" name="sex" id="frm-sex-m" value="m"> </label>
 	<label for="frm-sex-f"> <input type="radio" name="sex" id="frm-sex-f" value="f"> female</label>
@@ -91,13 +91,19 @@
 
 
 <form id="myForm" class="ajax" action="" method="post">
-	<input type="text" name="username" id="frm-username">
+	<input type="text" name="username" class="control-class" id="frm-username">
 <input type="hidden" name="id" value=""><!--[if IE]><input type=IEbug disabled style="display:none"><![endif]-->
 </form>
 
 
-<FORM action="" method="post">
-	<input type="text" name="username" id="frm-username">
+<form class="nclass" action="" method="post">
+	<input type="text" name="username" id="frm-username" class="nclass">
+<input type="hidden" name="id" value=""><!--[if IE]><input type=IEbug disabled style="display:none"><![endif]-->
+</form>
+
+
+<FORM action="" method="post" class="form-class">
+	<input type="text" name="username" class="control-class" id="frm-username">
 <input type="hidden" name="id" value=""><!--[if IE]><input type=IEbug disabled style="display:none"><![endif]-->
 </FORM>
 

--- a/tests/Forms.Latte/expected/FormMacros.forms.phtml
+++ b/tests/Forms.Latte/expected/FormMacros.forms.phtml
@@ -203,6 +203,24 @@
 
 
 <?php
+		$form = $_form = $this->global->formsStack[] = $this->global->uiControl["myForm"];
+		?><form<?php
+		if ($_tmp = array_filter(['nclass'])) echo ' class="', LR\Filters::escapeHtmlAttr(implode(" ", array_unique($_tmp))), '"';
+		echo Nette\Bridges\FormsLatte\Runtime::renderFormBegin(end($this->global->formsStack), array (
+		'class' => NULL,
+		), false) ?>>
+	<input<?php
+		$_input = end($this->global->formsStack)["username"];
+		echo $_input->getControlPart()->addAttributes(array (
+		'class' => NULL,
+		))->attributes();
+		if ($_tmp = array_filter(['nclass'])) echo ' class="', LR\Filters::escapeHtmlAttr(implode(" ", array_unique($_tmp))), '"' ?>>
+<?php
+		echo Nette\Bridges\FormsLatte\Runtime::renderFormEnd(array_pop($this->global->formsStack), false);
+?></form>
+
+
+<?php
 		$form = $_form = $this->global->formsStack[] = is_object($this->global->uiControl['myForm']) ? $this->global->uiControl['myForm'] : $this->global->uiControl[$this->global->uiControl['myForm']];
 		?><FORM<?php
 		echo Nette\Bridges\FormsLatte\Runtime::renderFormBegin(end($this->global->formsStack), array (
@@ -220,7 +238,7 @@
 		echo $_input->getControlPart()->attributes() ?>><?php echo $_input->getControl()->getHtml() ?></select>
 
 
-<textarea title="<?php echo LR\Filters::escapeHtmlAttr(10) /* line 71 */ ?>"<?php
+<textarea title="<?php echo LR\Filters::escapeHtmlAttr(10) /* line 76 */ ?>"<?php
 		$_input = end($this->global->formsStack)["area"];
 		echo $_input->getControlPart()->addAttributes(array (
 		'title' => NULL,

--- a/tests/Forms.Latte/templates/forms.latte
+++ b/tests/Forms.Latte/templates/forms.latte
@@ -60,6 +60,11 @@
 </form>
 
 
+<form n:name="myForm" n:class="nclass">
+	<input n:name=username n:class="nclass">
+</form>
+
+
 <FORM n:name="$this->global->uiControl[myForm]">
 	<input n:name=username>
 </FORM>


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

Currently `n:class` and `n:name` macros do not play well together. The problem is that `n:name` macro doesn't see `n:class` as html attribute, so it doesn't reset the class on the returned Html instance of form/label/control. This leads to HTML output with double `class="..."` attribute.
This PR solves the problem by adding explicit support for `n:class` into `FormMacros`.