### PR TITLE
HiddenField support addFilter and nullable

### DIFF
--- a/examples/bootstrap2-rendering.php
+++ b/examples/bootstrap2-rendering.php
@@ -30,23 +30,21 @@ function makeBootstrap2(Form $form)
 	$renderer->wrappers['control']['errorcontainer'] = 'span class=help-inline';
 	$form->getElementPrototype()->class('form-horizontal');
 
-	$form->onRender[] = function ($form) {
-		foreach ($form->getControls() as $control) {
-			$type = $control->getOption('type');
-			if ($type === 'button') {
-				$control->getControlPrototype()->addClass(empty($usedPrimary) ? 'btn btn-primary' : 'btn');
-				$usedPrimary = true;
+	foreach ($form->getControls() as $control) {
+		$type = $control->getOption('type');
+		if ($type === 'button') {
+			$control->getControlPrototype()->addClass(empty($usedPrimary) ? 'btn btn-primary' : 'btn');
+			$usedPrimary = true;
 
-			} elseif (in_array($type, ['checkbox', 'radio'], true)) {
-				$control->getSeparatorPrototype()->setName('div')->addClass($type);
-			}
+		} elseif (in_array($type, ['checkbox', 'radio'], true)) {
+			$control->getSeparatorPrototype()->setName('div')->addClass($type);
 		}
-	};
+	}
 }
 
 
 $form = new Form;
-makeBootstrap2($form);
+$form->onRender[] = 'makeBootstrap2';
 
 $form->addGroup('Personal data');
 $form->addText('name', 'Your name')

--- a/examples/bootstrap3-rendering.php
+++ b/examples/bootstrap3-rendering.php
@@ -30,26 +30,24 @@ function makeBootstrap3(Form $form)
 	$renderer->wrappers['control']['errorcontainer'] = 'span class=help-block';
 	$form->getElementPrototype()->class('form-horizontal');
 
-	$form->onRender[] = function ($form) {
-		foreach ($form->getControls() as $control) {
-			$type = $control->getOption('type');
-			if ($type === 'button') {
-				$control->getControlPrototype()->addClass(empty($usedPrimary) ? 'btn btn-primary' : 'btn btn-default');
-				$usedPrimary = true;
+	foreach ($form->getControls() as $control) {
+		$type = $control->getOption('type');
+		if ($type === 'button') {
+			$control->getControlPrototype()->addClass(empty($usedPrimary) ? 'btn btn-primary' : 'btn btn-default');
+			$usedPrimary = true;
 
-			} elseif (in_array($type, ['text', 'textarea', 'select'], true)) {
-				$control->getControlPrototype()->addClass('form-control');
+		} elseif (in_array($type, ['text', 'textarea', 'select'], true)) {
+			$control->getControlPrototype()->addClass('form-control');
 
-			} elseif (in_array($type, ['checkbox', 'radio'], true)) {
-				$control->getSeparatorPrototype()->setName('div')->addClass($type);
-			}
+		} elseif (in_array($type, ['checkbox', 'radio'], true)) {
+			$control->getSeparatorPrototype()->setName('div')->addClass($type);
 		}
-	};
+	}
 }
 
 
 $form = new Form;
-makeBootstrap3($form);
+$form->onRender[] = 'makeBootstrap3';
 
 $form->addGroup('Personal data');
 $form->addText('name', 'Your name')

--- a/examples/bootstrap4-rendering.php
+++ b/examples/bootstrap4-rendering.php
@@ -29,35 +29,33 @@ function makeBootstrap4(Form $form)
 	$renderer->wrappers['control']['description'] = 'span class=form-text';
 	$renderer->wrappers['control']['errorcontainer'] = 'span class=form-control-feedback';
 
-	$form->onRender[] = function ($form) {
-		foreach ($form->getControls() as $control) {
-			$type = $control->getOption('type');
-			if ($type === 'button') {
-				$control->getControlPrototype()->addClass(empty($usedPrimary) ? 'btn btn-primary' : 'btn btn-secondary');
-				$usedPrimary = true;
+	foreach ($form->getControls() as $control) {
+		$type = $control->getOption('type');
+		if ($type === 'button') {
+			$control->getControlPrototype()->addClass(empty($usedPrimary) ? 'btn btn-primary' : 'btn btn-secondary');
+			$usedPrimary = true;
 
-			} elseif (in_array($type, ['text', 'textarea', 'select'], true)) {
-				$control->getControlPrototype()->addClass('form-control');
+		} elseif (in_array($type, ['text', 'textarea', 'select'], true)) {
+			$control->getControlPrototype()->addClass('form-control');
 
-			} elseif ($type === 'file') {
-				$control->getControlPrototype()->addClass('form-control-file');
+		} elseif ($type === 'file') {
+			$control->getControlPrototype()->addClass('form-control-file');
 
-			} elseif (in_array($type, ['checkbox', 'radio'], true)) {
-				if ($control instanceof Nette\Forms\Controls\Checkbox) {
-					$control->getLabelPrototype()->addClass('form-check-label');
-				} else {
-					$control->getItemLabelPrototype()->addClass('form-check-label');
-				}
-				$control->getControlPrototype()->addClass('form-check-input');
-				$control->getSeparatorPrototype()->setName('div')->addClass('form-check');
+		} elseif (in_array($type, ['checkbox', 'radio'], true)) {
+			if ($control instanceof Nette\Forms\Controls\Checkbox) {
+				$control->getLabelPrototype()->addClass('form-check-label');
+			} else {
+				$control->getItemLabelPrototype()->addClass('form-check-label');
 			}
+			$control->getControlPrototype()->addClass('form-check-input');
+			$control->getSeparatorPrototype()->setName('div')->addClass('form-check');
 		}
-	};
+	}
 }
 
 
 $form = new Form;
-makeBootstrap4($form);
+$form->onRender[] = 'makeBootstrap4';
 
 $form->addGroup('Personal data');
 $form->addText('name', 'Your name')
@@ -99,7 +97,7 @@ if ($form->isSuccess()) {
 <meta charset="utf-8">
 <title>Nette Forms & Bootstrap v4 rendering example</title>
 
-<link rel="stylesheet" href="http://v4-alpha.getbootstrap.com/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css">
 
 <div class="container">
 	<h1>Nette Forms & Bootstrap v4 rendering example</h1>

--- a/examples/custom-control.php
+++ b/examples/custom-control.php
@@ -20,7 +20,9 @@ class DateInput extends Nette\Forms\Controls\BaseControl
 {
 	/** @var string */
 	private $day = '';
+
 	private $month = '';
+
 	private $year = '';
 
 

--- a/tests/Forms/Controls.CsrfProtection.phpt
+++ b/tests/Forms/Controls.CsrfProtection.phpt
@@ -32,15 +32,15 @@ Assert::same('hidden', $input->getOption('type'));
 $input->setValue(null);
 Assert::false(CsrfProtection::validateCsrf($input));
 
-call_user_func([$input, 'Nette\Forms\Controls\BaseControl::setValue'], '12345678901234567890123456789012345678');
+call_user_func([$input, 'Nette\Forms\Controls\HiddenField::setValue'], '12345678901234567890123456789012345678');
 Assert::false(CsrfProtection::validateCsrf($input));
 
 $value = $input->getControl()->value;
-call_user_func([$input, 'Nette\Forms\Controls\BaseControl::setValue'], $value);
+call_user_func([$input, 'Nette\Forms\Controls\HiddenField::setValue'], $value);
 Assert::true(CsrfProtection::validateCsrf($input));
 
 session_regenerate_id();
-call_user_func([$input, 'Nette\Forms\Controls\BaseControl::setValue'], $value);
+call_user_func([$input, 'Nette\Forms\Controls\HiddenField::setValue'], $value);
 Assert::false(CsrfProtection::validateCsrf($input));
 
 

--- a/tests/Forms/Controls.HiddenField.loadData.phpt
+++ b/tests/Forms/Controls.HiddenField.loadData.phpt
@@ -68,9 +68,36 @@ test(function () { // setValue() and invalid argument
 test(function () { // object
 	$form = new Form;
 	$input = $form->addHidden('hidden')
-		->setValue(new Nette\Utils\DateTime('2013-07-05'));
+		->setValue($data = new Nette\Utils\DateTime('2013-07-05'));
 
-	Assert::same('2013-07-05 00:00:00', $input->getValue());
+	Assert::same($data, $input->getValue());
+});
+
+
+test(function () { // object from string by filter
+	$date = new Nette\Utils\DateTime('2013-07-05');
+	$_POST = ['text' => (string) $date];
+	$form = new Form;
+	$input = $form->addHidden('text');
+	$input->addFilter(function ($value) {
+		return $value ? new \Nette\Utils\DateTime($value) : $value;
+	});
+
+	Assert::same((string) $date, $input->getValue());
+	$input->validate();
+	Assert::equal($date, $input->getValue());
+});
+
+
+test(function () { // int from string
+	$_POST = ['text' => '10'];
+	$form = new Form;
+	$input = $form->addHidden('text');
+	$input->addRule($form::INTEGER);
+
+	Assert::same('10', $input->getValue());
+	$input->validate();
+	Assert::equal(10, $input->getValue());
 });
 
 
@@ -80,4 +107,21 @@ test(function () { // persistent
 	$input->setValue('other');
 
 	Assert::same('persistent', $input->getValue());
+});
+
+
+test(function () { // nullable
+	$form = new Form;
+	$input = $form['hidden'] = new Nette\Forms\Controls\HiddenField();
+	$input->setNullable();
+	Assert::null($input->getValue());
+});
+
+
+test(function () { // nullable
+	$form = new Form;
+	$input = $form['hidden'] = new Nette\Forms\Controls\HiddenField();
+	$input->setValue(null);
+	$input->setNullable();
+	Assert::null($input->getValue());
 });


### PR DESCRIPTION
- bug fix? no (issue #152)
- new feature? yes
- BC break? yes

Based on issue #152 `HiddenField` now supports `addFilter()`. Due to this new behavior is necessary support nullable also.

BC break: HiddenField now returns set value, no it's string version.