### PR TITLE
Validator: method validatePattern() check FileUpload and use right name

### DIFF
--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -248,7 +248,8 @@ class Validator
 	 */
 	public static function validatePattern(IControl $control, string $pattern): bool
 	{
-		return (bool) Strings::match($control->getValue(), "\x01^(?:$pattern)\\z\x01u");
+		$value = $control->getValue() instanceof Nette\Http\FileUpload ? $control->getValue()->getName() : $control->getValue();
+		return (bool) Strings::match($value, "\x01^(?:$pattern)\\z\x01u");
 	}
 
 

--- a/tests/Forms/Controls.TestBase.validators.phpt
+++ b/tests/Forms/Controls.TestBase.validators.phpt
@@ -7,7 +7,9 @@
 declare(strict_types=1);
 
 use Nette\Forms\Controls\TextInput;
+use Nette\Forms\Controls\UploadControl;
 use Nette\Forms\Validator;
+use Nette\Http\FileUpload;
 use Tester\Assert;
 
 
@@ -91,6 +93,21 @@ test(function () {
 	Assert::false(Validator::validatePattern($control, '[0-9]'));
 	Assert::true(Validator::validatePattern($control, '[0-9]+x'));
 	Assert::false(Validator::validatePattern($control, '[0-9]+X'));
+
+
+	$control = new class extends UploadControl {
+		public function setValue($value)
+		{
+			$this->value = $value;
+			return $this;
+		}
+	};
+
+	$control->value = new FileUpload([
+		'name' => '123x', 'size' => 1, 'tmp_name' => '456y', 'error' => UPLOAD_ERR_OK, 'type' => '',
+	]);
+	Assert::false(Validator::validatePattern($control, '[4-6]+y'));
+	Assert::true(Validator::validatePattern($control, '[1-3]+x'));
 });
 
 


### PR DESCRIPTION
- bug fix? yes  [issue](/nette/http/issues/130)
- new feature? no
- BC break? no
- doc PR: nette/docs#???  not necessary

Validator accept pattern for FileUpload::getName() instance of FileUplaod::__toString(), where is tmpName.
```
$form->addUpload('csv')
    ->addRule($form::MIME_TYPE, 'Foo', 'text/*')
    ->addRule($form::PATTERN, 'Message', '.*\.csv');
```