### PR TITLE
TextBase support mixed as value

### DIFF
--- a/src/Forms/Controls/TextBase.php
+++ b/src/Forms/Controls/TextBase.php
@@ -11,6 +11,7 @@ namespace Nette\Forms\Controls;
 
 use Nette;
 use Nette\Forms\Form;
+use Nette\Forms\ScalarValue;
 use Nette\Utils\Strings;
 
 
@@ -41,7 +42,7 @@ abstract class TextBase extends BaseControl
 		} elseif (!is_scalar($value) && !method_exists($value, '__toString')) {
 			throw new Nette\InvalidArgumentException(sprintf("Value must be scalar or null, %s given in field '%s'.", gettype($value), $this->name));
 		}
-		$this->value = $value;
+		$this->value = $value instanceof ScalarValue ? $value->getMixedValue() : $value;
 		$this->rawValue = (string) $value;
 		return $this;
 	}

--- a/src/Forms/ScalarValue.php
+++ b/src/Forms/ScalarValue.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Forms;
+
+
+class ScalarValue
+{
+
+	/** @var string */
+	private $scalarValue;
+
+	/** @var mixed */
+	private $mixedValue;
+
+
+	public function __construct(string $scalarValue, $mixedValue)
+	{
+		$this->scalarValue = $scalarValue;
+		$this->mixedValue = $mixedValue;
+	}
+
+
+	/**
+	 * @return mixed
+	 */
+	public function getMixedValue()
+	{
+		return $this->mixedValue;
+	}
+
+
+	public function __toString(): string
+	{
+		return $this->scalarValue;
+	}
+}

--- a/tests/Forms/Controls.BaseControl.phpt
+++ b/tests/Forms/Controls.BaseControl.phpt
@@ -7,6 +7,7 @@
 declare(strict_types=1);
 
 use Nette\Forms\Form;
+use Nette\Forms\ScalarValue;
 use Nette\Forms\Validator;
 use Tester\Assert;
 
@@ -144,4 +145,31 @@ test(function () { // disabled & submitted
 	$form['disabled'] = $input;
 
 	Assert::same('default', $input->getValue());
+});
+
+
+test(function () { // scalarValue
+	$form = new Form;
+	$input = $form->addText('text');
+	$input->setValue(new ScalarValue( 'scalarValue', null));
+
+	Assert::null($input->getValue());
+	Assert::same('<input type="text" name="text" id="frm-text" value="scalarValue">', (string) $input->getControl());
+});
+
+
+test(function () { // scalarValue from filter
+	$form = new Form;
+
+	$input = $form->addText('text');
+	$input->setValue('scalarValue');
+	$input->addFilter(function (string $scalarValue): ScalarValue {
+		return new ScalarValue($scalarValue, 'mixedValue');
+	});
+
+	$form->validate();
+
+	Assert::same('mixedValue', $input->getValue());
+	Assert::same('<input type="text" name="text" id="frm-text" value="scalarValue">', (string) $input->getControl());
+	Assert::true(Validator::validateFilled($input));
 });

--- a/tests/Forms/Controls.BaseControl.phpt
+++ b/tests/Forms/Controls.BaseControl.phpt
@@ -151,7 +151,7 @@ test(function () { // disabled & submitted
 test(function () { // scalarValue
 	$form = new Form;
 	$input = $form->addText('text');
-	$input->setValue(new ScalarValue( 'scalarValue', null));
+	$input->setValue(new ScalarValue('scalarValue', null));
 
 	Assert::null($input->getValue());
 	Assert::same('<input type="text" name="text" id="frm-text" value="scalarValue">', (string) $input->getControl());


### PR DESCRIPTION
- bug fix? no 
- new feature? yes
- BC break? no

adds support for 
```php
// class without __toString method
final class User {
  // ..
}

$repo = function(string $userName): ?User {
   return new User;
}

$form = new Nette\Forms\Form;
$form->addText('user', 'Username')
  ->addFilter(function (string $userName) use ($repo) {
    return new Nette\Forms\ScalarValue($userName, $repo($userName)));
  } )
;

$form->onSuccess[] = function(Nette\Forms\Form $form, array $values): void {
  $values['user'] instanceof User || null;
};

```


<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
