### PR TITLE
Rules: added reset method

### DIFF
--- a/src/Forms/Rules.php
+++ b/src/Forms/Rules.php
@@ -278,6 +278,15 @@ class Rules implements \IteratorAggregate
 
 
 	/**
+	 * Clear all validation rules.
+	 */
+	public function reset()
+	{
+		$this->rules = [];
+	}
+
+
+	/**
 	 * Validates single rule.
 	 * @return bool
 	 */

--- a/tests/Forms/Rules.reset.phpt
+++ b/tests/Forms/Rules.reset.phpt
@@ -1,0 +1,35 @@
+<?php
+
+use Nette\Forms\Form;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test(function () {
+	$form = new Form;
+	$input = $form->addText('text');
+	$input->addCondition(false)
+		->setRequired();
+
+	Assert::count(1, iterator_to_array($input->getRules()));
+	$input->getRules()->reset();
+
+	Assert::count(0, iterator_to_array($input->getRules()));
+});
+
+
+test(function () {
+	$form = new Form;
+	$input1 = $form->addText('text1');
+	$input2 = $form->addText('text2');
+	$input2->addConditionOn($input1, $form::FILLED)
+		->addRule($form::BLANK);
+
+	Assert::count(0, iterator_to_array($input1->getRules()));
+	Assert::count(1, iterator_to_array($input2->getRules()));
+	$input2->getRules()->reset();
+
+	Assert::count(0, iterator_to_array($input2->getRules()));
+});


### PR DESCRIPTION
- new feature: yes
- BC break? yno
- doc PR: not yet

Ability to reset already attached rules on control. It's not possible to attach different rules in modular systems. Or is it?
 
```php
$form = new Form;
$input = $form->addText('text');
$input->addCondition(Form::MAX_LENGTH, 5)
	->addRule(Form::PATTERN, 'Musí obsahovat číslici', '.*[0-9].*');
$input->getRules()->reset();
```

Reset method is marked as internal.