### PR TITLE
DefaultFormRenderer: fix input name defined like array

### DIFF
--- a/src/Forms/Rendering/DefaultFormRenderer.php
+++ b/src/Forms/Rendering/DefaultFormRenderer.php
@@ -172,7 +172,8 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 			foreach (preg_split('#[;&]#', $query, -1, PREG_SPLIT_NO_EMPTY) as $param) {
 				$parts = explode('=', $param, 2);
 				$name = urldecode($parts[0]);
-				if (!isset($this->form[$name])) {
+				$itemName = explode('[', $name, 2)[0];
+				if (!isset($this->form[$itemName])) {
 					$s .= Html::el('input', ['type' => 'hidden', 'name' => $name, 'value' => urldecode($parts[1])]);
 				}
 			}

--- a/tests/Forms/Forms.renderer.4.phpt
+++ b/tests/Forms/Forms.renderer.4.phpt
@@ -13,7 +13,9 @@ require __DIR__ . '/../bootstrap.php';
 
 $form = new Nette\Forms\Form;
 $form->setMethod('GET');
-$form->setAction('link?a=b&c[]=d');
+$form->setAction('link?a=b&c[]=d&list[0]=1');
+$form->addCheckboxList('list')
+	->setItems(['First', 'Second']);
 $form->addHidden('userid');
 $form->addSubmit('submit', 'Send');
 
@@ -24,6 +26,12 @@ Assert::match('<form action="link" method="get">
 
 <table>
 <tr>
+	<th><label></label></th>
+
+	<td><label><input type="checkbox" name="list[]" value="0">First</label><br><label><input type="checkbox" name="list[]" value="1">Second</label></td>
+</tr>
+
+<tr>
 	<th></th>
 
 	<td><input type="submit" name="_submit" value="Send" class="button"></td>
@@ -33,4 +41,4 @@ Assert::match('<form action="link" method="get">
 <input type="hidden" name="userid" value=""><!--[if IE]><input type=IEbug disabled style="display:none"><![endif]-->
 </form>', $form->__toString(true));
 
-Assert::same('link?a=b&c[]=d', $form->getAction());
+Assert::same('link?a=b&c[]=d&list[0]=1', $form->getAction());


### PR DESCRIPTION
- bug fix #181 
- BC break? no
- doc PR: not need

Item name is generated from parameter, where remove from first left bracket to end. For example list[foo][0] -> list.



