### PR TITLE
netteForms.js: support checking file name via pattern rule

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -449,8 +449,24 @@
 		},
 
 		pattern: function(elem, arg, val) {
+			if (typeof arg !== 'string') {
+				return null;
+			}
+
 			try {
-				return typeof arg === 'string' ? (new RegExp('^(?:' + arg + ')$')).test(val) : null;
+				var regExp = new RegExp('^(?:' + arg + ')$');
+
+				if (window.FileList && val instanceof FileList) {
+					for (var i = 0; i < val.length; i++) {
+						if (!regExp.test(val[i].name)) {
+							return false;
+						}
+					}
+
+					return true;
+				}
+
+				return regExp.test(val);
 			} catch (e) {} // eslint-disable-line no-empty
 		},
 


### PR DESCRIPTION
- bug fix / new feature? a little bit of both
- BC break? no
- doc PR: not necessary I believe

This is a complement to #175 so validating file names via pattern works on both client and server.

I'm not sure how backporting to `v2.4` works - do you do that manually? Anything I need to do?
Not sure how to write tests for this - to _select_ a file in the test environment to test this. Appreciate any pointers.

Thank you. 