### PR TITLE
Validator: method validatePattern() for UploadControl multiple

### DIFF
--- a/src/Forms/Controls/BaseControl.php
+++ b/src/Forms/Controls/BaseControl.php
@@ -336,8 +336,8 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	public function getHtmlId()
 	{
 		if (!isset($this->control->id)) {
-			$form = $this->getForm(false);
-			$this->control->id = sprintf(self::$idMask, $this->lookupPath(), $form ? $form->getName() : '');
+			$form = $this->getForm();
+			$this->control->id = sprintf(self::$idMask, $this->lookupPath(), $form->getName());
 		}
 		return $this->control->id;
 	}

--- a/src/Forms/Controls/BaseControl.php
+++ b/src/Forms/Controls/BaseControl.php
@@ -337,7 +337,10 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	{
 		if (!isset($this->control->id)) {
 			$form = $this->getForm();
-			$this->control->id = sprintf(self::$idMask, $this->lookupPath(), $form->getName());
+			$prefix = $form instanceof Nette\Application\UI\Form || $form->getName() === null
+				? ''
+				: $form->getName() . '-';
+			$this->control->id = sprintf(self::$idMask, $prefix . $this->lookupPath());
 		}
 		return $this->control->id;
 	}

--- a/src/Forms/Controls/BaseControl.php
+++ b/src/Forms/Controls/BaseControl.php
@@ -336,7 +336,8 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	public function getHtmlId()
 	{
 		if (!isset($this->control->id)) {
-			$this->control->id = sprintf(self::$idMask, $this->lookupPath());
+			$form = $this->getForm(false);
+			$this->control->id = sprintf(self::$idMask, $this->lookupPath(), $form ? $form->getName() : '');
 		}
 		return $this->control->id;
 	}

--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -251,8 +251,14 @@ class Validator
 	 */
 	public static function validatePattern(IControl $control, string $pattern, bool $caseInsensitive = false): bool
 	{
-		$value = $control->getValue() instanceof Nette\Http\FileUpload ? $control->getValue()->getName() : $control->getValue();
-		return (bool) Strings::match($value, "\x01^(?:$pattern)\\z\x01u" . ($caseInsensitive ? 'i' : ''));
+		$matchPattern = "\x01^(?:$pattern)\\z\x01u" . ($caseInsensitive ? 'i' : '');
+		foreach (static::toArray($control->getValue()) as $item) {
+			$value = $item instanceof Nette\Http\FileUpload ? $item->getName() : $item;
+			if (Strings::match($value, $matchPattern) === null) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 

--- a/tests/Forms/Controls.TestBase.validators.phpt
+++ b/tests/Forms/Controls.TestBase.validators.phpt
@@ -120,6 +120,18 @@ test(function () {
 	]);
 	Assert::false(Validator::validatePattern($control, '[4-6]+y'));
 	Assert::true(Validator::validatePattern($control, '[1-3]+x'));
+
+	$control = new MockUploadControl(null, true);
+	$control->value = [new FileUpload([
+		'name' => 'foo.jpg', 'size' => 1, 'tmp_name' => 'foo1', 'error' => UPLOAD_ERR_OK, 'type' => '',
+	])];
+	Assert::true(Validator::validatePattern($control, '.*jpg'));
+
+	$control = new MockUploadControl(null, true);
+	$control->value = [new FileUpload([
+		'name' => 'bar.png', 'size' => 1, 'tmp_name' => 'bar1', 'error' => UPLOAD_ERR_OK, 'type' => '',
+	])];
+	Assert::false(Validator::validatePattern($control, '.*jpg'));
 });
 
 

--- a/tests/Forms/Forms.idMask.phpt
+++ b/tests/Forms/Forms.idMask.phpt
@@ -40,17 +40,13 @@ test(function () {
 
 
 test(function () {
-	Nette\Forms\Controls\BaseControl::$idMask = 'frm-%s-%s';
-
 	$form = new Form;
 	$input = $form->addText('name');
-	Assert::same('frm-name-', $input->getHtmlId());
+	Assert::same('frm-name', $input->getHtmlId());
 });
 
 
 test(function () {
-	Nette\Forms\Controls\BaseControl::$idMask = 'frm-%2$s-%1$s';
-
 	$form = new Form('signForm');
 	$input = $form->addText('name');
 	Assert::same('frm-signForm-name', $input->getHtmlId());

--- a/tests/Forms/Forms.idMask.phpt
+++ b/tests/Forms/Forms.idMask.phpt
@@ -13,15 +13,15 @@ require __DIR__ . '/../bootstrap.php';
 Assert::exception(function () {
 	$input = new TextInput('name');
 	$input->getHtmlId();
-}, Nette\InvalidStateException::class, "Component '' is not attached to ''.");
+}, Nette\InvalidStateException::class, "Component '' is not attached to 'Nette\\Forms\\Form'.");
 
 
-test(function () {
+Assert::exception(function () {
 	$container = new Nette\Forms\Container;
 	$container->setParent(null, 'second');
 	$input = $container->addText('name');
-	Assert::same('frm-name', $input->getHtmlId());
-});
+	$input->getHtmlId();
+}, Nette\InvalidStateException::class, "Component 'name' is not attached to 'Nette\\Forms\\Form'.");
 
 
 test(function () {

--- a/tests/Forms/Forms.idMask.phpt
+++ b/tests/Forms/Forms.idMask.phpt
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Forms\Form;
+use Nette\Forms\Controls\TextInput;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::exception(function () {
+	$input = new TextInput('name');
+	$input->getHtmlId();
+}, Nette\InvalidStateException::class, "Component '' is not attached to ''.");
+
+
+test(function () {
+	$container = new Nette\Forms\Container;
+	$container->setParent(null, 'second');
+	$input = $container->addText('name');
+	Assert::same('frm-name', $input->getHtmlId());
+});
+
+
+test(function () {
+	$form = new Form;
+	$container = $form->addContainer('second');
+	$input = $container->addText('name');
+	Assert::same('frm-second-name', $input->getHtmlId());
+});
+
+
+test(function () {
+	$form = new Form;
+	$input = $form->addText('name');
+	Assert::same('frm-name', $input->getHtmlId());
+});
+
+
+test(function () {
+	Nette\Forms\Controls\BaseControl::$idMask = 'frm-%s-%s';
+
+	$form = new Form;
+	$input = $form->addText('name');
+	Assert::same('frm-name-', $input->getHtmlId());
+});
+
+
+test(function () {
+	Nette\Forms\Controls\BaseControl::$idMask = 'frm-%2$s-%1$s';
+
+	$form = new Form('signForm');
+	$input = $form->addText('name');
+	Assert::same('frm-signForm-name', $input->getHtmlId());
+});


### PR DESCRIPTION
- bug fix #190 
- BC break? no
- doc PR: no

The method validatePattern accepts $control where value can be array by UploadControl (multiple). If one file does not matched method return false.

I extend the test method because two classes MockUploadControl are not allowed.
