### PR TITLE
ChoiceControl: added prependItems() and appendItems() methods [WIP]

### DIFF
--- a/src/Forms/Controls/ChoiceControl.php
+++ b/src/Forms/Controls/ChoiceControl.php
@@ -113,6 +113,43 @@ abstract class ChoiceControl extends BaseControl
 
 
 	/**
+	 * Prepend one item to the item list.
+	 * @param  mixed           $item
+	 * @param  string|int|null $key
+	 * @return static
+	 */
+	public function prependItem($item, $key = null, bool $reindexKeys = false)
+	{
+		if ($key === null && $reindexKeys) {
+			array_unshift($this->items, $item);
+			return $this;
+		}
+
+		$this->items = [($key === null ? $item : $key) => $item] + $this->items;
+		return $this;
+	}
+
+
+	/**
+	 * Append one item to the item list.
+	 * @param  mixed           $item
+	 * @param  string|int|null $key
+	 * @param  bool            $numericKey
+	 * @return static
+	 */
+	public function appendItem($item, $key = null, bool $numericKeys = false)
+	{
+		if ($key === null && $numericKeys) {
+			$this->items[] = $item;
+			return $this;
+		}
+
+		$this->items[$key !== null ? $key : $item] = $item;
+		return $this;
+	}
+
+
+	/**
 	 * Returns items from which to choose.
 	 */
 	public function getItems(): array

--- a/src/Forms/Controls/ChoiceControl.php
+++ b/src/Forms/Controls/ChoiceControl.php
@@ -113,38 +113,23 @@ abstract class ChoiceControl extends BaseControl
 
 
 	/**
-	 * Prepend one item to the item list.
-	 * @param  mixed           $item
-	 * @param  string|int|null $key
+	 * Prepends items from which to choose.
 	 * @return static
 	 */
-	public function prependItem($item, $key = null, bool $reindexKeys = false)
+	public function prependItems(array $items, bool $useKeys = true)
 	{
-		if ($key === null && $reindexKeys) {
-			array_unshift($this->items, $item);
-			return $this;
-		}
-
-		$this->items = [($key === null ? $item : $key) => $item] + $this->items;
+		$this->items = array_merge($useKeys ? $items : array_combine($items, $items), $this->items);
 		return $this;
 	}
 
 
 	/**
-	 * Append one item to the item list.
-	 * @param  mixed           $item
-	 * @param  string|int|null $key
-	 * @param  bool            $numericKey
+	 * Appends items from which to choose.
 	 * @return static
 	 */
-	public function appendItem($item, $key = null, bool $numericKeys = false)
+	public function appendItems(array $items, bool $useKeys = true)
 	{
-		if ($key === null && $numericKeys) {
-			$this->items[] = $item;
-			return $this;
-		}
-
-		$this->items[$key !== null ? $key : $item] = $item;
+		$this->items = array_merge($this->items, $useKeys ? $items : array_combine($items, $items));
 		return $this;
 	}
 

--- a/tests/Forms/Controls.ChoiceControl.setItems.phpt
+++ b/tests/Forms/Controls.ChoiceControl.setItems.phpt
@@ -35,7 +35,7 @@ test(function () {
 
 test(function () {
 	$choiceCOntrol = new ChoiceControl(null, ['A' => 'A']);
-	$choiceCOntrol->prependItem('B');
+	$choiceCOntrol->prependItems(['B'], false);
 
 	Assert::same(['B' => 'B', 'A' => 'A'], $choiceCOntrol->getItems());
 });
@@ -43,15 +43,15 @@ test(function () {
 
 test(function () {
 	$choiceCOntrol = new ChoiceControl(null, ['A' => 'A']);
-	$choiceCOntrol->prependItem('B', 'C');
+	$choiceCOntrol->prependItems(['B' => 'C']);
 
-	Assert::same(['C' => 'B', 'A' => 'A'], $choiceCOntrol->getItems());
+	Assert::same(['B' => 'C', 'A' => 'A'], $choiceCOntrol->getItems());
 });
 
 
 test(function () {
 	$choiceCOntrol = new ChoiceControl(null, ['A']);
-	$choiceCOntrol->prependItem('B', null, true);
+	$choiceCOntrol->prependItems(['B']);
 
 	Assert::same([0 => 'B', 1 => 'A'], $choiceCOntrol->getItems());
 });
@@ -59,7 +59,7 @@ test(function () {
 
 test(function () {
 	$choiceCOntrol = new ChoiceControl(null, ['A' => 'A']);
-	$choiceCOntrol->appendItem('B');
+	$choiceCOntrol->appendItems(['B'], false);
 
 	Assert::same(['A' => 'A', 'B' => 'B'], $choiceCOntrol->getItems());
 });
@@ -67,15 +67,15 @@ test(function () {
 
 test(function () {
 	$choiceCOntrol = new ChoiceControl(null, ['A' => 'A']);
-	$choiceCOntrol->appendItem('B', 'C');
+	$choiceCOntrol->appendItems(['B' => 'C']);
 
-	Assert::same(['A' => 'A', 'C' => 'B'], $choiceCOntrol->getItems());
+	Assert::same(['A' => 'A', 'B' => 'C'], $choiceCOntrol->getItems());
 });
 
 
 test(function () {
 	$choiceCOntrol = new ChoiceControl(null, ['A']);
-	$choiceCOntrol->appendItem('B', null, true);
+	$choiceCOntrol->appendItems(['B']);
 
 	Assert::same([0 => 'A', 1 => 'B'], $choiceCOntrol->getItems());
 });

--- a/tests/Forms/Controls.ChoiceControl.setValues.phpt
+++ b/tests/Forms/Controls.ChoiceControl.setValues.phpt
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Test: Nette\Forms\Controls\ChoiceControl.
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class ChoiceControl extends Nette\Forms\Controls\ChoiceControl
+{
+}
+
+
+test(function () {
+	$choiceCOntrol = new ChoiceControl();
+	$choiceCOntrol->setItems(['A', 'B']);
+
+	Assert::same([0 => 'A', 1 => 'B'], $choiceCOntrol->getItems());
+});
+
+
+test(function () {
+	$choiceCOntrol = new ChoiceControl();
+	$choiceCOntrol->setItems(['A', 'B'], false);
+
+	Assert::same(['A' => 'A', 'B' => 'B'], $choiceCOntrol->getItems());
+});
+
+
+test(function () {
+	$choiceCOntrol = new ChoiceControl(null, ['A' => 'A']);
+	$choiceCOntrol->prependItem('B');
+
+	Assert::same(['B' => 'B', 'A' => 'A'], $choiceCOntrol->getItems());
+});
+
+
+test(function () {
+	$choiceCOntrol = new ChoiceControl(null, ['A' => 'A']);
+	$choiceCOntrol->prependItem('B', 'C');
+
+	Assert::same(['C' => 'B', 'A' => 'A'], $choiceCOntrol->getItems());
+});
+
+
+test(function () {
+	$choiceCOntrol = new ChoiceControl(null, ['A']);
+	$choiceCOntrol->prependItem('B', null, true);
+
+	Assert::same([0 => 'B', 1 => 'A'], $choiceCOntrol->getItems());
+});
+
+
+test(function () {
+	$choiceCOntrol = new ChoiceControl(null, ['A' => 'A']);
+	$choiceCOntrol->appendItem('B');
+
+	Assert::same(['A' => 'A', 'B' => 'B'], $choiceCOntrol->getItems());
+});
+
+
+test(function () {
+	$choiceCOntrol = new ChoiceControl(null, ['A' => 'A']);
+	$choiceCOntrol->appendItem('B', 'C');
+
+	Assert::same(['A' => 'A', 'C' => 'B'], $choiceCOntrol->getItems());
+});
+
+
+test(function () {
+	$choiceCOntrol = new ChoiceControl(null, ['A']);
+	$choiceCOntrol->appendItem('B', null, true);
+
+	Assert::same([0 => 'A', 1 => 'B'], $choiceCOntrol->getItems());
+});

--- a/tests/Forms/Forms.idMask.phpt
+++ b/tests/Forms/Forms.idMask.phpt
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Nette\Forms\Form;
 use Nette\Forms\Controls\TextInput;
+use Nette\Forms\Form;
 use Tester\Assert;
 
 


### PR DESCRIPTION
* new feature
* BC break: no

Sometimes I need to add one item to `SelectBox` choices. For example when I have select of current vat rates, but old invoice has old vat rate set. These methods make this much easier.

It would be nice to backport this to `v2.4` too.