### PR TITLE
Validator: add support for value objects

### DIFF
--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -225,7 +225,7 @@ class Validator
 	 */
 	public static function validateEmail(IControl $control): bool
 	{
-		return Validators::isEmail($control->getValue());
+		return Validators::isEmail((string) $control->getValue());
 	}
 
 
@@ -234,10 +234,12 @@ class Validator
 	 */
 	public static function validateUrl(IControl $control): bool
 	{
-		if (Validators::isUrl($value = $control->getValue())) {
+		$value = (string) $control->getValue();
+		if (Validators::isUrl($value)) {
 			return true;
-
-		} elseif (Validators::isUrl($value = "http://$value")) {
+		}
+		$value = "http://$value";
+		if (Validators::isUrl($value)) {
 			$control->setValue($value);
 			return true;
 		}

--- a/tests/Forms/Controls.TextInput.valueObjectValidation.phpt
+++ b/tests/Forms/Controls.TextInput.valueObjectValidation.phpt
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Test: Nette\Forms\Controls\TextInput.
+ */
+
+declare(strict_types=1);
+
+use Nette\Forms\Form;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class ValueObject
+{
+	/** @var string */
+	private $value;
+
+
+	public function __construct(string $value)
+	{
+		$this->value = $value;
+	}
+
+
+	public function __toString(): string
+	{
+		return $this->value;
+	}
+}
+
+
+test(function (): void { // e-mail
+	$form = new Form;
+	$input = $form->addEmail('email');
+
+	$input->setValue(new ValueObject('example@example.com'));
+	Assert::type(ValueObject::class, $input->getValue());
+	$form->validate();
+	Assert::same([], $form->getErrors());
+});
+
+
+test(function (): void { // URL
+	$form = new Form;
+	$input = $form->addText('url')
+		->addRule(Form::URL);
+
+	$input->setValue(new ValueObject('https://example.com'));
+	Assert::type(ValueObject::class, $input->getValue());
+	$form->validate();
+	Assert::same([], $form->getErrors());
+
+	$input->setValue(new ValueObject('example.com'));
+	Assert::type(ValueObject::class, $input->getValue());
+	$form->validate();
+	Assert::same([], $form->getErrors());
+});


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: not really needed

With introduction of scalar typehints it became impossible to use a couple of default validators with input controls that return value objects. This PR adds typecasts to URL and EMAIL validator to restore value object support.