### PR TITLE
Validator::validatePattern(): fix value object support (fixes #205)

### DIFF
--- a/examples/bootstrap4-rendering.php
+++ b/examples/bootstrap4-rendering.php
@@ -28,6 +28,7 @@ function makeBootstrap4(Form $form): void
 	$renderer->wrappers['label']['container'] = 'div class="col-sm-3 col-form-label"';
 	$renderer->wrappers['control']['description'] = 'span class=form-text';
 	$renderer->wrappers['control']['errorcontainer'] = 'span class=form-control-feedback';
+	$renderer->wrappers['control']['.error'] = 'is-invalid';
 
 	foreach ($form->getControls() as $control) {
 		$type = $control->getOption('type');

--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -10,12 +10,13 @@ declare(strict_types=1);
 namespace Nette\Forms;
 
 use Nette;
+use Nette\Utils\ArrayHash;
 
 
 /**
  * Container for form controls.
  *
- * @property   Nette\Utils\ArrayHash $values
+ * @property   ArrayHash $values
  * @property-read \Iterator $controls
  * @property-read Form|null $form
  */
@@ -34,6 +35,9 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/** @var bool */
 	private $validated;
+
+	/** @var string */
+	private $mappedType = ArrayHash::class;
 
 
 	/********************* data exchange ****************d*g**/
@@ -96,20 +100,36 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Returns the values submitted by the form.
-	 * @return Nette\Utils\ArrayHash|array
+	 * @param  string|null  $returnType  'array' for array
+	 * @return object|array
 	 */
-	public function getValues(bool $asArray = false)
+	public function getValues($returnType = null)
 	{
-		$values = $asArray ? [] : new Nette\Utils\ArrayHash;
+		$returnType = $returnType
+			? ($returnType === true ? 'array' : $returnType) // back compatibility
+			: $this->mappedType;
+
+		$isArray = $returnType === 'array';
+		$obj = $isArray ? new \stdClass : new $returnType;
+
 		foreach ($this->getComponents() as $name => $control) {
 			if ($control instanceof IControl && !$control->isOmitted()) {
-				$values[$name] = $control->getValue();
-
+				$obj->$name = $control->getValue();
 			} elseif ($control instanceof self) {
-				$values[$name] = $control->getValues($asArray);
+				$obj->$name = $control->getValues($isArray ? 'array' : null);
 			}
 		}
-		return $values;
+		return $isArray ? (array) $obj : $obj;
+	}
+
+
+	/**
+	 * @return static
+	 */
+	public function setMappedType(string $type)
+	{
+		$this->mappedType = $type;
+		return $this;
 	}
 
 
@@ -148,7 +168,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 			}
 			foreach ($this->onValidate as $handler) {
 				$params = Nette\Utils\Callback::toReflection($handler)->getParameters();
-				$values = isset($params[1]) ? $this->getValues($params[1]->isArray()) : null;
+				$values = isset($params[1]) ? $this->getValues((string) $params[1]->getType()) : null;
 				$handler($this, $values);
 			}
 		}

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -416,7 +416,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 	{
 		foreach ($handlers as $handler) {
 			$params = Nette\Utils\Callback::toReflection($handler)->getParameters();
-			$values = isset($params[1]) ? $this->getValues($params[1]->isArray()) : null;
+			$values = isset($params[1]) ? $this->getValues((string) $params[1]->getType()) : null;
 			$handler($button ?: $this, $values);
 			if (!$this->isValid()) {
 				return;

--- a/src/Forms/Rendering/DefaultFormRenderer.php
+++ b/src/Forms/Rendering/DefaultFormRenderer.php
@@ -47,7 +47,7 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 	 *          \---
 	 *
 	 *          /--- control.container [.odd]
-	 *            .... CONTROL [.required .text .password .file .submit .button]
+	 *            .... CONTROL [.required .error .text .password .file .submit .button]
 	 *            .... control.requiredsuffix
 	 *            .... control.description
 	 *            .... control.errorcontainer + control.erroritem
@@ -95,6 +95,7 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 			'erroritem' => '',
 
 			'.required' => 'required',
+			'.error' => null,
 			'.text' => 'text',
 			'.password' => 'text',
 			'.file' => 'text',
@@ -386,8 +387,12 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 
 			$control->setOption('rendered', true);
 			$el = $control->getControl();
-			if ($el instanceof Html && $el->getName() === 'input') {
-				$el->class($this->getValue("control .$el->type"), true);
+			if ($el instanceof Html) {
+				if ($el->getName() === 'input') {
+					$el->class($this->getValue("control .$el->type"), true);
+				}
+
+				$el->class($this->getValue('control .error'), $control->hasErrors());
 			}
 			$s[] = $el . $description;
 		}
@@ -447,8 +452,12 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 
 		$control->setOption('rendered', true);
 		$el = $control->getControl();
-		if ($el instanceof Html && $el->getName() === 'input') {
-			$el->class($this->getValue("control .$el->type"), true);
+		if ($el instanceof Html) {
+			if ($el->getName() === 'input') {
+				$el->class($this->getValue("control .$el->type"), true);
+			}
+
+			$el->class($this->getValue('control .error'), $control->hasErrors());
 		}
 		return $body->setHtml($el . $description . $this->renderErrors($control));
 	}

--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -254,7 +254,7 @@ class Validator
 		$regexp = "\x01^(?:$pattern)\\z\x01u" . ($caseInsensitive ? 'i' : '');
 		foreach (static::toArray($control->getValue()) as $item) {
 			$value = $item instanceof Nette\Http\FileUpload ? $item->getName() : $item;
-			if (!Strings::match($value, $regexp)) {
+			if (!Strings::match((string) $value, $regexp)) {
 				return false;
 			}
 		}
@@ -353,6 +353,6 @@ class Validator
 
 	private static function toArray($value): array
 	{
-		return $value instanceof Nette\Http\FileUpload ? [$value] : (array) $value;
+		return is_object($value) ? [$value] : (array) $value;
 	}
 }

--- a/tests/Forms/Container.values.array.phpt
+++ b/tests/Forms/Container.values.array.phpt
@@ -150,6 +150,61 @@ test(function () { // setValues() + array
 });
 
 
+test(function () { // getValues(...arguments...)
+	$_SERVER['REQUEST_METHOD'] = 'POST';
+
+	$form = createForm();
+
+	Assert::truthy($form->isSubmitted());
+
+	$form->setValues([
+		'title' => 'new1',
+		'first' => [
+			'name' => 'new2',
+		],
+	]);
+
+	Assert::equal([
+		'title' => 'new1',
+		'first' => [
+			'name' => 'new2',
+			'age' => '999',
+			'second' => [
+				'city' => 'sent city',
+			],
+		],
+	], $form->getValues('array'));
+});
+
+
+test(function () { // setMappedType(array)
+	$_SERVER['REQUEST_METHOD'] = 'POST';
+
+	$form = createForm();
+	$form->setMappedType('array');
+
+	Assert::truthy($form->isSubmitted());
+
+	$form->setValues([
+		'title' => 'new1',
+		'first' => [
+			'name' => 'new2',
+		],
+	]);
+
+	Assert::equal([
+		'title' => 'new1',
+		'first' => [
+			'name' => 'new2',
+			'age' => '999',
+			'second' => [
+				'city' => 'sent city',
+			],
+		],
+	], $form->getValues());
+});
+
+
 test(function () { // onSuccess test
 	$_SERVER['REQUEST_METHOD'] = 'POST';
 

--- a/tests/Forms/Controls.TestBase.validators.phpt
+++ b/tests/Forms/Controls.TestBase.validators.phpt
@@ -97,6 +97,26 @@ test(function () {
 
 test(function () {
 	$control = new TextInput;
+
+
+	$control->value = new class () {
+		public $lorem = 'ipsum';
+
+
+		public function __toString(): string
+		{
+			return '123x';
+		}
+	};
+
+
+	Assert::false(Validator::validatePattern($control, '[0-9]'));
+	Assert::true(Validator::validatePattern($control, '[0-9]+x'));
+	Assert::false(Validator::validatePattern($control, '[0-9]+X'));
+});
+
+test(function () {
+	$control = new TextInput;
 	$control->value = '123x';
 	Assert::false(Validator::validatePatternCaseInsensitive($control, '[0-9]'));
 	Assert::true(Validator::validatePatternCaseInsensitive($control, '[0-9]+x'));

--- a/tests/Forms/Forms.renderer.2.expect
+++ b/tests/Forms/Forms.renderer.2.expect
@@ -13,7 +13,7 @@
 
 	<dt><label for="frm-age" class="required">Your age:</label></dt>
 
-	<dd class="odd"><input type="number" name="age" min="10" max="100" id="frm-age" required data-nette-rules='[{"op":":filled","msg":"Enter your age"},{"op":":integer","msg":"Age must be numeric value"},{"op":":range","msg":"Age must be in range from 10 to 100","arg":[10,100]}]' value="9.9" class="text"> •
+	<dd class="odd"><input type="number" name="age" min="10" max="100" id="frm-age" required data-nette-rules='[{"op":":filled","msg":"Enter your age"},{"op":":integer","msg":"Age must be numeric value"},{"op":":range","msg":"Age must be in range from 10 to 100","arg":[10,100]}]' value="9.9" class="text is-invalid"> •
 
 	<span class="error">
 		Age must be numeric value
@@ -24,7 +24,7 @@
 
 	<dt><label for="frm-gender">Your gender:</label></dt>
 
-	<dd><select name="gender" id="frm-gender"><option style="color: #248bd3" value="m">male</option><option style="color: #e948d4" value="f">female</option></select>
+	<dd><select name="gender" id="frm-gender" class="is-invalid"><option style="color: #248bd3" value="m">male</option><option style="color: #e948d4" value="f">female</option></select>
 
 	<span class="error">
 		Please select a valid option.
@@ -81,7 +81,7 @@
 
 	<dt><label for="frm-password" class="required">Choose password:</label></dt>
 
-	<dd><input type="password" name="password" id="frm-password" required data-nette-rules='[{"op":":filled","msg":"Choose your password"},{"op":":minLength","msg":"The password is too short: it must be at least 3 characters","arg":3}]' class="text"> • <small>(at least 3 characters)</small>
+	<dd><input type="password" name="password" id="frm-password" required data-nette-rules='[{"op":":filled","msg":"Choose your password"},{"op":":minLength","msg":"The password is too short: it must be at least 3 characters","arg":3}]' class="text is-invalid"> • <small>(at least 3 characters)</small>
 
 	<span class="error">
 		The password is too short: it must be at least 3 characters

--- a/tests/Forms/Forms.renderer.2.phpt
+++ b/tests/Forms/Forms.renderer.2.phpt
@@ -46,6 +46,7 @@ $renderer->wrappers['pair']['container'] = null;
 $renderer->wrappers['controls']['container'] = 'dl';
 $renderer->wrappers['control']['container'] = 'dd';
 $renderer->wrappers['control']['.odd'] = 'odd';
+$renderer->wrappers['control']['.error'] = 'is-invalid';
 $renderer->wrappers['control']['errors'] = true;
 $renderer->wrappers['label']['container'] = 'dt';
 $renderer->wrappers['label']['suffix'] = ':';


### PR DESCRIPTION
- bug fix #205 
- BC break? don't think so
- doc PR: not needed

See #205 for details. The PR targets master, but should be backported to 2.4 branch as well, because the change that introduced this issue (#192) was already backported.