### PR TITLE
netteForms.js: support for toggling by css class, not only id

### DIFF
--- a/src/assets/netteForms.js
+++ b/src/assets/netteForms.js
@@ -655,9 +655,16 @@
 	 * Displays or hides HTML element.
 	 */
 	Nette.toggle = function(id, visible, srcElement) { // eslint-disable-line no-unused-vars
-		var elem = document.getElementById(id);
-		if (elem) {
-			elem.style.display = visible ? '' : 'none';
+		if (id.indexOf('.') === 0) {
+			var elems = document.getElementsByClassName(id.substr(1));
+			for (var i = 0; i < elems.length; i++) {
+				elems[i].style.display = visible ? '' : 'none';
+			}
+		} else {
+			var elem = document.getElementById(id);
+			if (elem) {
+				elem.style.display = visible ? '' : 'none';
+			}
 		}
 	};
 


### PR DESCRIPTION
- new feature
- BC break? no

this is useful eg. for controls manually rendered as table cells `<td>` which have only `<tr>` valid parent .. if there are multiple cells within table row toggling via `id` is not feasible (it would toggle all the cells in that row).