### PR TITLE
typo

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -237,7 +237,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 
 	/**
 	 * Removes fieldset group from form.
-	 * @param  string|int|ControlGroup  $name
+	 * @param  string|ControlGroup  $name
 	 */
 	public function removeGroup($name): void
 	{


### PR DESCRIPTION
If you pass integer, always you throw a exception.