### PR TITLE
Use phpstan callable definitions

### DIFF
--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -26,7 +26,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	private const ARRAY = 'array';
 
-	/** @var callable[]  function (Container $sender): void; Occurs when the form is validated */
+	/** @var callable[]&(callable(Container): void)[]; Occurs when the form is validated */
 	public $onValidate;
 
 	/** @var ControlGroup|null */

--- a/src/Forms/Controls/SubmitButton.php
+++ b/src/Forms/Controls/SubmitButton.php
@@ -19,10 +19,10 @@ use Nette;
  */
 class SubmitButton extends Button implements Nette\Forms\ISubmitterControl
 {
-	/** @var callable[]  function (SubmitButton $sender): void; Occurs when the button is clicked and form is successfully validated */
+	/** @var callable[]&(callable(SubmitButton): void)[]; Occurs when the button is clicked and form is successfully validated */
 	public $onClick;
 
-	/** @var callable[]  function (SubmitButton $sender): void; Occurs when the button is clicked and form is not validated */
+	/** @var callable[]&(callable(SubmitButton): void)[]; Occurs when the button is clicked and form is not validated */
 	public $onInvalidClick;
 
 	/** @var array|null */

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -81,16 +81,16 @@ class Form extends Container implements Nette\Utils\IHtmlString
 	/** @internal protection token ID */
 	public const PROTECTOR_ID = '_token_';
 
-	/** @var callable[]  function (Form $sender): void; Occurs when the form is submitted and successfully validated */
+	/** @var callable[]&((callable(Form, array): void)|(callable(Form, ArrayHash): void))[]; Occurs when the form is submitted and successfully validated */
 	public $onSuccess;
 
-	/** @var callable[]  function (Form $sender): void; Occurs when the form is submitted and is not valid */
+	/** @var callable[]&(callable(Form): void)[]; Occurs when the form is submitted and is not valid */
 	public $onError;
 
-	/** @var callable[]  function (Form $sender): void; Occurs when the form is submitted */
+	/** @var callable[]&(callable(Form): void)[]; Occurs when the form is submitted */
 	public $onSubmit;
 
-	/** @var callable[]  function (Form $sender): void; Occurs before the form is rendered */
+	/** @var callable[]&(callable(Form): void)[]; Occurs before the form is rendered */
 	public $onRender;
 
 	/** @var Nette\Http\IRequest  used only by standalone form */


### PR DESCRIPTION
- new feature
- BC break? no

Hi,
are you interested in definition for callables like phpstan does?
format is like in php (without parameter names) `callable(params): return_type`

If you are interested I can change other classes/packages.