### PR TITLE
Validator::formatMessage: support dynamic error messages

### DIFF
--- a/src/Forms/Helpers.php
+++ b/src/Forms/Helpers.php
@@ -102,6 +102,9 @@ class Helpers
 				}
 				$op = Nette\Utils\Callback::toString($op);
 			}
+			if (is_callable($rule->message)) {
+				continue;
+			}
 			if ($rule->branch) {
 				$item = [
 					'op' => ($rule->isNegative ? '~' : '') . $op,

--- a/src/Forms/Rules.php
+++ b/src/Forms/Rules.php
@@ -69,7 +69,7 @@ class Rules implements \IteratorAggregate
 	/**
 	 * Adds a validation rule for the current control.
 	 * @param  callable|string  $validator
-	 * @param  string|object  $errorMessage
+	 * @param  string|callable|object  $errorMessage
 	 * @return static
 	 */
 	public function addRule($validator, $errorMessage = null, $arg = null)

--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -51,6 +51,15 @@ class Validator
 	public static function formatMessage(Rule $rule, bool $withValue = true)
 	{
 		$message = $rule->message;
+		if (is_callable($message)) {
+			$params = Nette\Utils\Callback::toReflection($message)->getParameters();
+			if (isset($params[1])) {
+				$message = $message($rule->control, $rule->arg);
+			} else {
+				$message = $message($rule->control);
+			}
+		}
+
 		if ($message instanceof Nette\Utils\IHtmlString) {
 			return $message;
 

--- a/tests/Forms/Helpers.exportRules.phpt
+++ b/tests/Forms/Helpers.exportRules.phpt
@@ -6,6 +6,7 @@
 
 declare(strict_types=1);
 
+use Nette\Forms\Controls\TextInput;
 use Nette\Forms\Form;
 use Nette\Forms\Helpers;
 use Tester\Assert;
@@ -90,4 +91,14 @@ test(function () {
 			'control' => 'text1',
 		],
 	], Helpers::exportRules($input2->getRules()));
+});
+
+
+test(function () {
+	$form = new Form;
+	$input = $form->addText('text');
+	$input->addRule(Form::EMAIL, function (TextInput $input, $arg) {
+		return $input->getValue() . ' is not valid e-mail address.';
+	});
+	Assert::same([], Helpers::exportRules($input->getRules()));
 });


### PR DESCRIPTION
This is useful when you want to show user an informative error message, whose text depends on some external data that depends on the value of some other field.

For example, my form allows user to choose a category of a team. Each category has a different limit for number of allowed members, which is specified in config.neon. I want to show the user the limit as part of the error message when she manages to exceed the limit.

- new feature
- BC break? no
- doc PR: none yet
