### PR TITLE
bug fix DefaultFormRenderer

### DIFF
--- a/src/Forms/Rendering/DefaultFormRenderer.php
+++ b/src/Forms/Rendering/DefaultFormRenderer.php
@@ -167,7 +167,7 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 
 		if ($this->form->isMethod('get')) {
 			$el = clone $this->form->getElementPrototype();
-			$query = parse_url($el->action, PHP_URL_QUERY);
+			$query = parse_url($el->action, PHP_URL_QUERY) ?: '';
 			$el->action = str_replace("?$query", '', $el->action);
 			$s = '';
 			foreach (preg_split('#[;&]#', $query, -1, PREG_SPLIT_NO_EMPTY) as $param) {

--- a/tests/Forms/Forms.renderer.6.phpt
+++ b/tests/Forms/Forms.renderer.6.phpt
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Test: Nette\Forms default rendering GET form.
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$form = new Nette\Forms\Form;
+$form->setMethod('GET');
+$form->setAction('link');
+$form->addCheckboxList('list')
+	->setItems(['First', 'Second']);
+$form->addHidden('userid');
+$form->addSubmit('submit', 'Send');
+
+$form->fireEvents();
+
+Assert::match('<form action="link" method="get">
+
+<table>
+<tr>
+	<th><label></label></th>
+
+	<td><label><input type="checkbox" name="list[]" value="0">First</label><br><label><input type="checkbox" name="list[]" value="1">Second</label></td>
+</tr>
+
+<tr>
+	<th></th>
+
+	<td><input type="submit" name="_submit" value="Send" class="button"></td>
+</tr>
+</table>
+
+<input type="hidden" name="userid" value=""><!--[if IE]><input type=IEbug disabled style="display:none"><![endif]-->
+</form>', $form->__toString(true));
+
+Assert::same('link', $form->getAction());


### PR DESCRIPTION
- bug fix
- BC break? no
- doc PR:

After update on new version with strict_type=1, `DefaultFormRenderer` started throw `TypeError: preg_split() expects parameter 2 to be string, null given` for forms with method `GET` if action URL does not contain query string parameters.