### PR TITLE
DefaultFormRenderer: Fix GET Application\UI\Form

### DIFF
--- a/src/Forms/Rendering/DefaultFormRenderer.php
+++ b/src/Forms/Rendering/DefaultFormRenderer.php
@@ -167,6 +167,7 @@ class DefaultFormRenderer implements Nette\Forms\IFormRenderer
 
 		if ($this->form->isMethod('get')) {
 			$el = clone $this->form->getElementPrototype();
+			$el->action = (string) $el->action;
 			$query = parse_url($el->action, PHP_URL_QUERY) ?: '';
 			$el->action = str_replace("?$query", '', $el->action);
 			$s = '';

--- a/tests/Forms/Forms.objectAction.phpt
+++ b/tests/Forms/Forms.objectAction.phpt
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Forms\Form;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::noError(function () {
+	$form = new Form;
+	$form->setMethod($form::GET);
+	$form->setAction(new class {
+		public function __toString(): string
+		{
+			return '/some/link';
+		}
+	});
+
+	echo $form;
+});


### PR DESCRIPTION
`Forms\Form` allows to pass stringable objects to `setAction` method, which is also used by `Application\UI\Form` to store `Application\UI\Link` object. `DefaultFormRenderer` calls string manipulation functions on the `Form’s` action when rendering, causing it to raise a `TypeError` when strict types are enabled.

To fix this, I am stringifying the action in the `DefaultFormRenderer`. I have opted to do it there, rather than in the `Form::setAction` method, in case the `Link` object is not ready yet at the time the `Form` is created.

Closes: https://github.com/nette/application/issues/218