### PR TITLE
Revert callable type of Form::$onSuccess to accept mixed

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Nette\Forms;
 
 use Nette;
+use Nette\Utils\ArrayHash;
 use Nette\Utils\Html;
 
 

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -81,7 +81,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 	/** @internal protection token ID */
 	public const PROTECTOR_ID = '_token_';
 
-	/** @var callable[]&((callable(Form, array): void)|(callable(Form, Nette\Utils\ArrayHash): void))[]; Occurs when the form is submitted and successfully validated */
+	/** @var callable[]&((callable(Form, mixed): void))[]; Occurs when the form is submitted and successfully validated */
 	public $onSuccess;
 
 	/** @var callable[]&(callable(Form): void)[]; Occurs when the form is submitted and is not valid */

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Nette\Forms;
 
 use Nette;
-use Nette\Utils\ArrayHash;
 use Nette\Utils\Html;
 
 
@@ -82,7 +81,7 @@ class Form extends Container implements Nette\Utils\IHtmlString
 	/** @internal protection token ID */
 	public const PROTECTOR_ID = '_token_';
 
-	/** @var callable[]&((callable(Form, array): void)|(callable(Form, ArrayHash): void))[]; Occurs when the form is submitted and successfully validated */
+	/** @var callable[]&((callable(Form, array): void)|(callable(Form, Nette\Utils\ArrayHash): void))[]; Occurs when the form is submitted and successfully validated */
 	public $onSuccess;
 
 	/** @var callable[]&(callable(Form): void)[]; Occurs when the form is submitted and is not valid */


### PR DESCRIPTION
- bug fix, related to #216 
- BC break? no
- doc PR: not needed

See [forum thread](https://forum.nette.org/cs/32188-staticka-analyza-kodu-po-aktualizaci-knihoven-na-nette-3-pri-lvl-5-hlasi-chyby#p204424). The import was missing, causing static analysis to report false positives.