### PR TITLE
Document the second param for onValidate callback

### DIFF
--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -26,7 +26,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	private const ARRAY = 'array';
 
-	/** @var callable[]&(callable(Container): void)[]; Occurs when the form is validated */
+	/** @var callable[]&(callable(Container, mixed): void)[]; Occurs when the form is validated */
 	public $onValidate;
 
 	/** @var ControlGroup|null */


### PR DESCRIPTION
- bug fix / new feature? bug fix (no issue number)
- BC break? no

The second parameter for `onValidate` callback (`$values`) documented as `mixed` to follow the consensus for `onSuccess` (in #223)

Thanks!