### PR TITLE
Validator::formatMessage() same label translations

### DIFF
--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -65,13 +65,17 @@ class Validator
 			$message = $translator->translate($message, is_int($rule->arg) ? $rule->arg : null);
 		}
 
-		$message = preg_replace_callback('#%(name|label|value|\d+\$[ds]|[ds])#', function (array $m) use ($rule, $withValue) {
+		$message = preg_replace_callback('#%(name|label|value|\d+\$[ds]|[ds])#', function (array $m) use ($rule, $withValue, $translator) {
 			static $i = -1;
 			switch ($m[1]) {
 				case 'name': return $rule->control->getName();
 				case 'label':
 					if ($rule->control instanceof Controls\BaseControl) {
-						$caption = $rule->control->translate($rule->control->getCaption());
+						if ($translator) {
+							$caption = $translator->translate($rule->control->getCaption());
+						} else {
+							$caption = $rule->control->translate($rule->control->getCaption());
+						}
 						return rtrim($caption instanceof Nette\Utils\Html ? $caption->getText() : $caption, ':');
 					}
 					return '';


### PR DESCRIPTION
- bug fix? yes
- BC break? no

The validator does not return the same label if the translator is null.