### PR TITLE
Validator: relax parameter typehints

### DIFF
--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -323,9 +323,10 @@ class Validator
 	/**
 	 * Is file size in limit?
 	 */
-	public static function validateFileSize(Controls\UploadControl $control, $limit): bool
+	public static function validateFileSize(IControl $control, $limit): bool
 	{
 		foreach (static::toArray($control->getValue()) as $file) {
+			Validators::assert($file, Nette\Http\FileUpload::class, 'control value');
 			if ($file->getSize() > $limit || $file->getError() === UPLOAD_ERR_INI_SIZE) {
 				return false;
 			}
@@ -338,10 +339,11 @@ class Validator
 	 * Has file specified mime type?
 	 * @param  string|string[]  $mimeType
 	 */
-	public static function validateMimeType(Controls\UploadControl $control, $mimeType): bool
+	public static function validateMimeType(IControl $control, $mimeType): bool
 	{
 		$mimeTypes = is_array($mimeType) ? $mimeType : explode(',', $mimeType);
 		foreach (static::toArray($control->getValue()) as $file) {
+			Validators::assert($file, Nette\Http\FileUpload::class, 'control value');
 			$type = strtolower($file->getContentType());
 			if (!in_array($type, $mimeTypes, true) && !in_array(preg_replace('#/.*#', '/*', $type), $mimeTypes, true)) {
 				return false;
@@ -354,9 +356,10 @@ class Validator
 	/**
 	 * Is file image?
 	 */
-	public static function validateImage(Controls\UploadControl $control): bool
+	public static function validateImage(IControl $control): bool
 	{
 		foreach (static::toArray($control->getValue()) as $file) {
+			Validators::assert($file, Nette\Http\FileUpload::class, 'control value');
 			if (!$file->isImage()) {
 				return false;
 			}

--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -131,18 +131,23 @@ class Validator
 	/**
 	 * Is control filled?
 	 */
-	public static function validateFilled(Controls\BaseControl $control): bool
+	public static function validateFilled(IControl $control): bool
 	{
-		return $control->isFilled();
+		if ($control instanceof Controls\BaseControl || method_exists($control, 'isFilled')) {
+			return $control->isFilled();
+		}
+
+		$value = $control->getValue();
+		return $value !== null && $value !== [] && $value !== '';
 	}
 
 
 	/**
 	 * Is control not filled?
 	 */
-	public static function validateBlank(Controls\BaseControl $control): bool
+	public static function validateBlank(IControl $control): bool
 	{
-		return !$control->isFilled();
+		return !static::validateFilled($control);
 	}
 
 

--- a/tests/Forms/Validator.customControl.phpt
+++ b/tests/Forms/Validator.customControl.phpt
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 use Nette\Forms\Form;
 use Nette\Forms\Validator;
+use Nette\Http\FileUpload;
+use Nette\Utils\AssertionException;
 use Tester\Assert;
 
 
@@ -73,4 +75,48 @@ test(function () { // filled, blank
 	$input = new CustomControl(42);
 	Assert::true(Validator::validateFilled($input));
 	Assert::false(Validator::validateBlank($input));
+});
+
+
+test(function () { // file upload related validators
+	$input = new CustomControl(new FileUpload([
+		'name' => 'foo',
+		'size' => 1,
+		'tmp_name' => __FILE__,
+		'error' => UPLOAD_ERR_OK
+	]));
+	Assert::true(Validator::validateFileSize($input, 42));
+	Assert::true(Validator::validateMimeType($input, ['text/x-php']));
+	Assert::false(Validator::validateImage($input));
+
+	$input = new CustomControl(new FileUpload([
+		'name' => 'foo',
+		'size' => 100,
+		'tmp_name' => __DIR__ . '/files/logo.gif',
+		'error' => UPLOAD_ERR_OK
+	]));
+	Assert::false(Validator::validateFileSize($input, 42));
+	Assert::false(Validator::validateMimeType($input, ['text/x-php']));
+	Assert::true(Validator::validateImage($input));
+
+	Assert::exception(
+		function () : void {
+			Assert::false(Validator::validateFileSize(new CustomControl('foo'), 42));
+		},
+		AssertionException::class
+	);
+
+	Assert::exception(
+		function () : void {
+			Assert::false(Validator::validateMimeType(new CustomControl('foo'), ['plain/text']));
+		},
+		AssertionException::class
+	);
+
+	Assert::exception(
+		function () : void {
+			Assert::false(Validator::validateImage(new CustomControl('foo')));
+		},
+		AssertionException::class
+	);
 });

--- a/tests/Forms/Validator.customControl.phpt
+++ b/tests/Forms/Validator.customControl.phpt
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Test: Nette\Forms\Controls\BaseControl
+ */
+
+declare(strict_types=1);
+
+use Nette\Forms\Form;
+use Nette\Forms\Validator;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class CustomControl implements \Nette\Forms\IControl
+{
+
+	private $value;
+
+
+	public function __construct($value)
+	{
+		$this->value = $value;
+	}
+
+
+	public function setValue($value)
+	{
+		$this->value = $value;
+	}
+
+
+	public function getValue()
+	{
+		return $this->value;
+	}
+
+
+	public function validate(): void
+	{
+	}
+
+
+	public function getErrors(): array
+	{
+		return [];
+	}
+
+
+	public function isOmitted(): bool
+	{
+		return false;
+	}
+
+}
+
+
+test(function () { // filled, blank
+	$input = new CustomControl('');
+	Assert::false(Validator::validateFilled($input));
+	Assert::true(Validator::validateBlank($input));
+
+	$input = new CustomControl(null);
+	Assert::false(Validator::validateFilled($input));
+	Assert::true(Validator::validateBlank($input));
+
+	$input = new CustomControl([]);
+	Assert::false(Validator::validateFilled($input));
+	Assert::true(Validator::validateBlank($input));
+
+	$input = new CustomControl(42);
+	Assert::true(Validator::validateFilled($input));
+	Assert::false(Validator::validateBlank($input));
+});


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: not needed

Some validation methods of form `Validator` require a specifc type of control instead of generic `IControl` interface. This means you can't use those validators with custom form controls (e.g. any control based on nextras/form-components). This is especially frustrating for the basic "filled" validator which is used if the form control is marked as required.

This PR relaxes the parameter typehints in backward compatible manner to allow validation of custom controls.