### PR TITLE
Container::addHidden Allow any type so it works same as setDefaultValue

### DIFF
--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -329,7 +329,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	/**
 	 * Adds hidden form control used to store a non-displayed value.
 	 */
-	public function addHidden(string $name, string $default = null): Controls\HiddenField
+	public function addHidden(string $name, $default = null): Controls\HiddenField
 	{
 		return $this[$name] = (new Controls\HiddenField)
 			->setDefaultValue($default);


### PR DESCRIPTION
- BC break? no

If setDefaultValue can receive any type then this should be supported in addHidden method as well.
Now it's strange that you cannot  do this:

`$this->addHidden('count', 0);`

but you can do:

`$this->addHidden('count')->setDefaultValue(5);`