### PR TITLE
strict types

### DIFF
--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -78,7 +78,7 @@ class Validator
 						$caption = $caption instanceof Nette\Utils\IHtmlString
 							? $caption->getText()
 							: ($translator ? $translator->translate($caption) : $caption);
-						return rtrim($caption, ':');
+						return rtrim((string) $caption, ':');
 					}
 					return '';
 				case 'value': return $withValue ? $rule->control->getValue() : $m[0];


### PR DESCRIPTION
- bug fix  <!-- #issue numbers, if any -->
- BC break? no

If $caption is null, php throws rtrim() expects parameter 1 to be string, null given
