### PR TITLE
strict fix

### DIFF
--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -116,6 +116,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 		$rc = new \ReflectionClass($obj);
 
 		foreach ($this->getComponents() as $name => $control) {
+			$name = (string) $name;
 			if ($control instanceof IControl && !$control->isOmitted()) {
 				$obj->$name = $control->getValue();
 			} elseif ($control instanceof self) {


### PR DESCRIPTION
- bug fix
- BC break? no

It breaked unit tests on  project, not sure if it's only unit tests or also code related as well, but whenever I have container which name was numeric I'm getting exception:

```
TypeError : ReflectionClass::hasProperty() expects parameter 1 to be string, int given
 /var/www/vendor/nette/forms/src/Forms/Container.php:124
```