### PR TITLE
Missing validator message should contain validator name.

### DIFF
--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -61,7 +61,12 @@ class Validator
 			$message = static::$messages[$rule->validator];
 
 		} elseif ($message == null) { // intentionally ==
-			trigger_error("Missing validation message for control '{$rule->control->getName()}' (validator '{$rule->validator}').", E_USER_WARNING);
+			trigger_error(
+				'Missing validation message for control \'' . $rule->control->getName() . '\''
+				. (is_string($rule->validator) ? ' (validator \'' . $rule->validator . '\')' : '')
+				. '.',
+				E_USER_WARNING
+			);
 		}
 
 		if ($translator = $rule->control->getForm()->getTranslator()) {

--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -61,7 +61,7 @@ class Validator
 			$message = static::$messages[$rule->validator];
 
 		} elseif ($message == null) { // intentionally ==
-			trigger_error("Missing validation message for control '{$rule->control->getName()}'.", E_USER_WARNING);
+			trigger_error("Missing validation message for control '{$rule->control->getName()}' (validator '{$rule->validator}').", E_USER_WARNING);
 		}
 
 		if ($translator = $rule->control->getForm()->getTranslator()) {


### PR DESCRIPTION
- new feature
- BC break? no

In case of:

```php
$form->addText('stars', 'Stars')
	->setRequired('Please select stars.')
	->addRule(Form::NUMERIC)
	->addRule(Form::MIN, null, 0)
	->addRule(Form::MAX, null, 5);
```

It is not clear from the original message in which validation rule the validation message is missing. The form can be built dynamically from multiple places. This feature adds the name of the validation rule that requires the message.

Thank you.