### PR TITLE
Form: addRule (regex) is not validating after addFilter

### DIFF
--- a/tests/Forms/Rules.valid.phpt
+++ b/tests/Forms/Rules.valid.phpt
@@ -42,6 +42,44 @@ test('', function () {
 	}, Nette\InvalidArgumentException::class, 'You cannot use Form::VALID in the addRule method.');
 });
 
+test('', function () {
+	$form = new Form;
+	$form->addText('foo')
+		->addFilter(function ($value) {
+			return str_replace(' ', '', $value);
+		})
+		->addRule($form::PATTERN, 'only numbers', '\d{5}');
+
+	$form['foo']->setValue('160 00');
+	$form->validate();
+	Assert::same([], $form->getErrors());
+
+	$form['foo']->setValue('160 00 x');
+	$form->validate();
+	Assert::same(['only numbers'], $form->getErrors());
+});
+
+
+test('', function () {
+	$form = new Form;
+	$foo = $form->addText('foo');
+	$rules = $foo->getRules();
+	$rules->addFilter(
+		function ($value) {
+			return str_replace(' ', '', $value);
+		}
+	);
+	$rules->addRule($form::PATTERN, 'only numbers', '\d{5}');
+
+	$form['foo']->setValue('160 00');
+	$form->validate();
+	Assert::same([], $form->getErrors());
+
+	$form['foo']->setValue('160 00 x');
+	$form->validate();
+	Assert::same(['only numbers'], $form->getErrors());
+});
+
 
 test('', function () {
 	Assert::exception(function () {


### PR DESCRIPTION
- bug fix
- BC break? no
- doc PR: 

Hello David @dg,

https://github.com/nette/docs/blob/doc-3.1/cs/form-validation.texy#L179-L192

When I tried `addFilter` as mentioned in docs, it does transform the value, but the validator after that does not validate.
Here is a failing test for that use-case.

I think that problem is here somewhere about here.

https://github.com/nette/forms/blob/master/src/Forms/Controls/TextInput.php#L72-L73

I am not sure, how to fix that, so I do not break anything else.

Thank you very much in advance.