### PR TITLE
BaseControl: narrow htmlId type

### DIFF
--- a/src/Forms/Controls/BaseControl.php
+++ b/src/Forms/Controls/BaseControl.php
@@ -22,7 +22,7 @@ use Stringable;
  *
  * @property-read Form $form
  * @property-read string $htmlName
- * @property   mixed $htmlId
+ * @property   string|bool $htmlId
  * @property   mixed $value
  * @property   string|Stringable $caption
  * @property   bool $disabled
@@ -307,7 +307,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements Con
 	/**
 	 * Returns control's HTML id.
 	 */
-	public function getHtmlId(): mixed
+	public function getHtmlId(): string|bool
 	{
 		if (!isset($this->control->id)) {
 			$form = $this->getForm();


### PR DESCRIPTION
- type annotation change
- BC break? yes

It can only be set to a string, bool or null but when set to null, it will be auto-generated as string. This is technically a BC break since if someone returns a wider type in an overloaded method of a subclass, it will break covariance.

I am not actually sure what the `bool` type is for, most uses of `getHtmlId()` just treat it as if it were of type `string`: https://github.com/nette/forms/search?q=getHtmlId