### PR TITLE
renderer - easier extensibility

### DIFF
--- a/src/Forms/Rendering/DefaultFormRenderer.php
+++ b/src/Forms/Rendering/DefaultFormRenderer.php
@@ -409,7 +409,7 @@ class DefaultFormRenderer implements Nette\Forms\FormRenderer
 			}
 
 			$control->setOption('rendered', true);
-			$el = $control->getControl();
+			$el = $this->renderFormElementControlMulti($control);
 			if ($el instanceof Html) {
 				if ($el->getName() === 'input') {
 					$el->class($this->getValue("control .$el->type"), true);
@@ -485,7 +485,7 @@ class DefaultFormRenderer implements Nette\Forms\FormRenderer
 		$els = $errors = [];
 		renderControl:
 		$control->setOption('rendered', true);
-		$el = $control->getControl();
+		$el = $this->renderFormElementControl($control);
 		if ($el instanceof Html) {
 			if ($el->getName() === 'input') {
 				$el->class($this->getValue("control .$el->type"), true);
@@ -506,6 +506,13 @@ class DefaultFormRenderer implements Nette\Forms\FormRenderer
 		return $body->setHtml(implode('', $els) . $description . $this->doRenderErrors($errors, true));
 	}
 
+	protected function renderFormElementControlMulti(Nette\Forms\Control $control): Html {
+		return $control->getControl();
+	}
+
+	protected function renderFormElementControl(Nette\Forms\Control $control): Html {
+		return $control->getControl();
+	}
 
 	public function getWrapper(string $name): Html
 	{


### PR DESCRIPTION
- Easier extensibility 
- BC break? no

Riesil som problem kde som potreboval upravit renderovanie checkboxu.

Nette `Checkbox::getControl` renderuje tuto struktutu
```
<div>
    <label>
        <checkbox />
    </label>
</div
```
Ja som ale potreboval toto
```
<div>
    <label />
    <checkbox />
</div>
```

Toto sa da dosiahnut len ak si extendnem `\Nette\Forms\Rendering\DefaultFormRenderer` a vnom extendnem 
- `\Nette\Forms\Rendering\DefaultFormRenderer::renderControl`
- `\Nette\Forms\Rendering\DefaultFormRenderer::renderPairMulti`
- `\Nette\Forms\Rendering\DefaultFormRenderer::doRenderErrors`

Vo funkciach `renderControl` a `renderPairMulti` kde je riadok `$el = $control->getControl();` sa robi to kuzlo ktore potrebujem. Tento pull request jednoducho tuto cast kodu vytiahne do funkcie ktoru je jednoduche extendnut a moj problem by bol jednoducho vyrieseny bez kopirovanie velkej casti renderera.