### PR TITLE
Removed `string` from return types of method BaseControl::getLabel()

### DIFF
--- a/src/Forms/Controls/BaseControl.php
+++ b/src/Forms/Controls/BaseControl.php
@@ -269,7 +269,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements Con
 	/**
 	 * Generates label's HTML element.
 	 * @param  string|object  $caption
-	 * @return Html|string|null
+	 * @return Html|null
 	 */
 	public function getLabel($caption = null)
 	{


### PR DESCRIPTION
Resloves https://github.com/nette/forms/issues/308