### PR TITLE
set SubmitterControl default to false

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -204,7 +204,7 @@ class Form extends Container implements Nette\HtmlStringable
 	public Nette\Http\IRequest $httpRequest;
 	protected bool $crossOrigin = false;
 	private static ?Nette\Http\IRequest $defaultHttpRequest = null;
-	private SubmitterControl|bool $submittedBy;
+	private SubmitterControl|bool $submittedBy = false;
 	private array $httpData;
 	private Html $element;
 	private FormRenderer $renderer;


### PR DESCRIPTION
In some cases we can use forms without even a submit button do validate some data, also sometimes in tests we do not add submit button because its maybe added elsewhere (onRender for example)...
Now  whenever this happens we get

 Typed property Nette\Forms\Form::$submittedBy must not be accessed before initialization, this should solve it.