### PR TITLE
Container::validate(): add Container to $controls param typehint

### DIFF
--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -219,7 +219,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 	/**
 	 * Performs the server side validation.
-	 * @param  Control[]|null  $controls
+	 * @param  (Control|self)[]|null  $controls
 	 */
 	public function validate(?array $controls = null): void
 	{


### PR DESCRIPTION
Containers are already supported, it just was not reflected in the type hint.

- bug fix
- BC break? no
- doc PR: no

<!--
Please use the latest released version (ie. last tagged commit) as a base for PR.

Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
