### PR TITLE
Use `self::TypeDate` as default for `DateTimeControl::$type`, not `self::Date`

### DIFF
--- a/src/Forms/Controls/DateTimeControl.php
+++ b/src/Forms/Controls/DateTimeControl.php
@@ -33,8 +33,11 @@ class DateTimeControl extends BaseControl
 	private string $format = self::FormatObject;
 
 
-	public function __construct(string|Stringable|null $label = null, int $type = self::Date, bool $withSeconds = false)
-	{
+	public function __construct(
+		string|Stringable|null $label = null,
+		int $type = self::TypeDate,
+		bool $withSeconds = false,
+	) {
 		$this->type = $type;
 		$this->withSeconds = $withSeconds;
 		parent::__construct($label);


### PR DESCRIPTION
- bug fix / new feature?   bugfix
- BC break? no

Use `self::TypeDate` as default for `DateTimeControl::$type`, not `self::Date`

This seems to be an unwanted change introduced in 3.2.1 in [01039d1](https://github.com/nette/forms/commit/01039d16add7973f06ac54ff3da37e85946d99e1#diff-db71c7b28f089ac2153db72b619314fa4b79ef034de79d6dab1120d47022b021R36).

Also reported by PHPStan here https://github.com/nette/forms/actions/runs/8458879610/job/23174056805#step:5:164