### PR TITLE
Fix bug in method setDefaults() used on disabled form control

### DIFF
--- a/src/Forms/Container.php
+++ b/src/Forms/Container.php
@@ -49,9 +49,8 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	public function setDefaults(array|object $data, bool $erase = false): static
 	{
 		$form = $this->getForm(false);
-		if (!$form || !$form->isAnchored() || !$form->isSubmitted()) {
-			$this->setValues($data, $erase);
-		}
+                $setDefaults = !$form || !$form->isAnchored() || !$form->isSubmitted();
+                $this->setValues($data, $erase, $setDefaults);
 
 		return $this;
 	}
@@ -61,7 +60,7 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	 * Fill-in with values.
 	 * @internal
 	 */
-	public function setValues(array|object $data, bool $erase = false): static
+	public function setValues(array|object $data, bool $erase = false, bool $setDefaults = false): static
 	{
 		if ($data instanceof \Traversable) {
 			$values = iterator_to_array($data);
@@ -73,7 +72,9 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 		foreach ($this->getComponents() as $name => $control) {
 			if ($control instanceof Control) {
 				if (array_key_exists($name, $values)) {
-					$control->setValue($values[$name]);
+                                    if ($control->isDisabled() || $setDefaults) {
+                                        $control->setValue($values[$name]);
+                                    }
 
 				} elseif ($erase) {
 					$control->setValue(null);

--- a/src/Forms/Controls/BaseControl.php
+++ b/src/Forms/Controls/BaseControl.php
@@ -179,16 +179,16 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements Con
 	/**
 	 * Disables or enables control.
 	 */
-	public function setDisabled(bool $value = true): static
-	{
-		if ($this->disabled = (bool) $value) {
-			$this->setValue(null);
-		} elseif (($form = $this->getForm(false)) && $form->isAnchored() && $form->isSubmitted()) {
-			$this->loadHttpData();
-		}
+	 public function setDisabled(bool $value = true)
+         {
+             $justEnabled = $this->disabled && $value === false;
+             $this->disabled = $value;
+             if($justEnabled && ($form = $this->getForm(false)) && $form->isAnchored() && $form->isSubmitted()){
+                 $this->loadHttpData();
+             }
+             return $this;
+         }
 
-		return $this;
-	}
 
 
 	/**


### PR DESCRIPTION
Method Container::setDefaults() use different algorithm for filling default values into disabled controls than method BaseControl::setDefaultValue(), this commit unified both algorithms and fixes bug with dissappearing default value in submitted forms

- bug fix
- BC break - no
- doc -problem is described on nette forum: https://forum.nette.org/cs/36480-rfc-container-setdefaults-opravit-chybu-basecontrol-setdisabled-vylepsit-funkci

The bug consists in the fact that if we send the default data setDefaults() to the form element that is disabled by setDisabled() after the anchor event of the form, the data will disappear after the form is submitted, which is undesirable behavior. If we use the setDefaultValue() method, the data does not disappear and it is OK. This PR changes algorithm in method setDefaults() to be identical with algorithm in setDefaultValue(). The chages were tested and the function of disabled control is 100% OK.
