### PR TITLE
Improve function setDisabled() - remove deleting of value

### DIFF
--- a/src/Forms/Controls/BaseControl.php
+++ b/src/Forms/Controls/BaseControl.php
@@ -181,11 +181,12 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements Con
 	 */
 	public function setDisabled(bool $value = true): static
 	{
-		if ($this->disabled = (bool) $value) {
-			$this->setValue(null);
-		} elseif (($form = $this->getForm(false)) && $form->isAnchored() && $form->isSubmitted()) {
-			$this->loadHttpData();
-		}
+                $justEnabled = $this->disabled && $value === false;
+                $this->disabled = $value;
+                if($justEnabled && ($form = $this->getForm(false)) && $form->isAnchored() && $form->isSubmitted()){
+                    $this->loadHttpData();
+                }
+
 
 		return $this;
 	}


### PR DESCRIPTION
Proposed change removes deleting value of disabled form control. The reason why deleting value was implemented in this method is from is unclear and is now obsolete. Deleting value of the control makes use of the method complicated and tricky while the deleting itself has no real meaning.

- new feature
- BC break yes
- detailed discussion is on nette forum: https://forum.nette.org/cs/36480-rfc-container-setdefaults-opravit-chybu-basecontrol-setdisabled-vylepsit-funkci
