### PR TITLE
Fix bug missing setting setOmitted(true) in Button.php

### DIFF
--- a/src/Forms/Controls/Button.php
+++ b/src/Forms/Controls/Button.php
@@ -23,6 +23,7 @@ class Button extends BaseControl
 		parent::__construct($caption);
 		$this->control->type = 'button';
 		$this->setOption('type', 'button');
+		$this->setOmitted(true);
 	}
 
 


### PR DESCRIPTION
If form is submitted with standard SubmitButton and in the form is another button Button, the attribute name + value appears in $values of the form. This is undesirable behaviour and my proposal fixes this bug.

- bug fix 
- BC break? no
- doc bug is described in detail on nette forume here https://forum.nette.org/cs/36506-osetrit-odesilana-data-tlacitka-nette-forms-controls-button#p226917

Notice: in the class Nette\Forms\Controls\SubmitButton in constructor is similar call setOmitted(true) which would be redundant after accepting this PR and could be removed for simplicity. I will send another PR.
