### PR TITLE
Form::getHttpData: Clarify return type

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -457,6 +457,7 @@ class Form extends Container implements Nette\HtmlStringable
 
 	/**
 	 * Returns submitted HTTP data.
+	 * @return ($htmlName is null ? array<mixed> : string|array<mixed>|Nette\Http\FileUpload|null)
 	 */
 	public function getHttpData(?int $type = null, ?string $htmlName = null): string|array|Nette\Http\FileUpload|null
 	{


### PR DESCRIPTION
The method will always return an array when `htmlId` is not specified. This will allow us to remove some PHPStan casts/checks in consuming projects.

- minor improvement
- BC break? no
- doc PR: n/a
