### PR TITLE
netteForms: do not propagate 'submit' event further when the form is invalid

### DIFF
--- a/src/assets/formValidator.ts
+++ b/src/assets/formValidator.ts
@@ -438,7 +438,7 @@ export class FormValidator {
 
 		form.addEventListener('submit', (e) => {
 			if (!this.validateForm((e.submitter || form) as HTMLFormElement | FormElement)) {
-				e.stopPropagation();
+				e.stopImmediatePropagation();
 				e.preventDefault();
 			}
 		});


### PR DESCRIPTION
- bug fix
- BC break? no
- doc PR: is it necessary?

As reported in https://forum.nette.org/cs/36618-duplicitni-dialog-netteformsmodal-s-ajaxem-naja-js, when somebody uses netteForms and Naja (>= 3.2) together, and netteForms are loaded (and auto-initialized) before Naja, both libraries consecutively trigger the form validation, which results in duplicate dialogs when there are validation errors.

This change prevents the `submit` event from propagating even to other listeners attached to the same form and event.