### PR TITLE
Fix selectBox prompt + required + checkDefaultValue = False

### DIFF
--- a/src/Forms/Controls/SelectBox.php
+++ b/src/Forms/Controls/SelectBox.php
@@ -106,6 +106,7 @@ class SelectBox extends ChoiceControl
 			}
 			$items = [$promptKey => $this->translate($this->prompt)] + $items;
 			if ($this->isRequired()) {
+				$selected = array_key_exists($this->value, $this->getItems()) ? $this->value : null;
 				$attrs['hidden:'][$promptKey] = $attrs['disabled:'][$promptKey] = true;
 				$selected ??= $promptKey; // disabled & selected for Safari, hidden for other browsers
 			}

--- a/tests/Forms/Controls.SelectBox.render.phpt
+++ b/tests/Forms/Controls.SelectBox.render.phpt
@@ -90,6 +90,33 @@ test('prompt + required', function () {
 	Assert::same('<select name="list" id="frm-list" required data-nette-rules=\'[{"op":":filled","msg":"This field is required."}]\'><option value="" disabled hidden>prompt</option><option value="a">First</option><option value="0" selected>Second</option></select>', (string) $input->getControl());
 });
 
+test('prompt + checkDefaultValueToFalse + value does not exist', function () {
+	$form = new Form;
+	$input = $form->addSelect('list', 'Label', [
+		'a' => 'First',
+		0 => 'Second',
+	])->setPrompt('prompt')->checkDefaultValue(false);
+
+	Assert::same('<select name="list" id="frm-list"><option value="">prompt</option><option value="a">First</option><option value="0">Second</option></select>', (string) $input->getControl());
+
+	$input->setValue('does not exists');
+
+	Assert::same('<select name="list" id="frm-list"><option value="">prompt</option><option value="a">First</option><option value="0">Second</option></select>', (string) $input->getControl());
+});
+
+test('prompt + required + checkDefaultValueToFalse + value does not exist', function () {
+	$form = new Form;
+	$input = $form->addSelect('list', 'Label', [
+		'a' => 'First',
+		0 => 'Second',
+	])->setPrompt('prompt')->setRequired()->checkDefaultValue(false);
+
+	Assert::same('<select name="list" id="frm-list" required data-nette-rules=\'[{"op":":filled","msg":"This field is required."}]\'><option value="" disabled hidden selected>prompt</option><option value="a">First</option><option value="0">Second</option></select>', (string) $input->getControl());
+
+	$input->setValue('does not exists');
+
+	Assert::same('<select name="list" id="frm-list" required data-nette-rules=\'[{"op":":filled","msg":"This field is required."}]\'><option value="" disabled hidden selected>prompt</option><option value="a">First</option><option value="0">Second</option></select>', (string) $input->getControl());
+});
 
 test('unique prompt', function () {
 	$form = new Form;


### PR DESCRIPTION
- bug fix 
- BC break? no

Example code:

```
$form->addSelect('country', 'Country', ['sk' => 'Slovakia', 'cz' => 'Czech Republic'])
    ->setRequired()	
    ->checkDefaultValue(false)
    ->setPrompt('-- select value --')
    ->setDefaultValue('en'); // value does not exists
```
The expected behavior is that the prompt will be selected but the first item is selected.
In version <= 3.2.1 this worked correctly.
